### PR TITLE
Bumped version to 5.8.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,9 +39,8 @@
 * We aks you not to use ```MailMergeLib``` for sending unsolicited bulk email.
 
 ### 5. Supported Frameworks
-* .Net Framework 4.6+
-* .Net Standard 2.1
-* .Net 5.0
+* .Net Framework 4.6.1 and later
+* .Net Standard 2.1 and later
 
 ### Get started
 [![NuGet](https://img.shields.io/nuget/v/MailMergeLib.svg)](https://www.nuget.org/packages/MailMergeLib/) Install the NuGet package
@@ -49,7 +48,3 @@
 [![Docs](https://img.shields.io/badge/docs-up%20to%20date-brightgreen.svg)](https://github.com/axuno/MailMergeLib/wiki)
 Have a look at the [MailMergeLib Wiki](https://github.com/axuno/MailMergeLib/wiki)
 
-### History
-MailMergeLib was introduced back in 2007 on [CodeProject](http://www.codeproject.com/Articles/19546/MailMergeLib-A-NET-Mail-Client-Library). The last version published there is 4.03. It is based on ```System.Net.Mail```. For anyone still using ```System.Net.Mail```, Jeffrey Stedfast's [Code Review](http://jeffreystedfast.blogspot.de/2015/03/code-review-microsofts-systemnetmail.html) might be interesting, although he describes issues more polite than they actually are (especially in terms of RFC violations).
-
-MailMergeLib 5 published on GitHub is a major rewrite, and it is not backwards compatible to prior releases. There is, however, a migration guide included in the ```MailMergeLib``` Wiki. 

--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -1,6 +1,14 @@
+# 5.8.0
+
+* Updated dependencies to latest versions
+  * Fixed compatibility issues with updated dependencies (specifically `MailKit`, `MimeKit` and `YAXLib` with new major versions).
+  * Now referencing updated [SmartFormat.Net v2.7.2](https://github.com/axuno/SmartFormat) for formatting.
+  * No impact on `MailMergeLib` public API.
+* Supported frameworks
+  * .Net Framework: 4.6.1 and later
+  * NetStandard: 2.1 and later
+
 # 5.7.1
-* Added support for NET5.0
-* MailMergeLib.Tests is now ```NetCore3.1```
 * Formatting (parse and format variables) can be switched off with ```MailMergeLib.EnableFormatter = false ```. Default is ```true```
 * Enabled SourceLink
 

--- a/Src/MailMergeLib.Tests/FakeSmtpClient.cs
+++ b/Src/MailMergeLib.Tests/FakeSmtpClient.cs
@@ -76,13 +76,13 @@ namespace MailMergeLib.Tests
             return Task.CompletedTask;
         }
 
-        public override Task SendAsync(FormatOptions options, MimeMessage message,
+        public override Task<string> SendAsync(FormatOptions options, MimeMessage message,
             CancellationToken cancellationToken = new CancellationToken(), ITransferProgress progress = null)
         {
-            throw new NotImplementedException();
+            throw new NotImplementedException(); 
         }
 
-        public override Task SendAsync(FormatOptions options, MimeMessage message, MailboxAddress sender, IEnumerable<MailboxAddress> recipients,
+        public override Task<string> SendAsync(FormatOptions options, MimeMessage message, MailboxAddress sender, IEnumerable<MailboxAddress> recipients,
             CancellationToken cancellationToken = new CancellationToken(), ITransferProgress progress = null)
         {
             throw new NotImplementedException();
@@ -162,16 +162,18 @@ namespace MailMergeLib.Tests
             return base.GetDeliveryStatusNotifications(message, mailbox);
         }
 
-        public override void Send(FormatOptions options, MimeMessage message, CancellationToken cancellationToken = new CancellationToken(),
+        public override string Send(FormatOptions options, MimeMessage message, CancellationToken cancellationToken = new CancellationToken(),
             ITransferProgress progress = null)
         {
             if (SendException != null) throw SendException;
+            return string.Empty;
         }
 
-        public override void Send(FormatOptions options, MimeMessage message, MailboxAddress sender, IEnumerable<MailboxAddress> recipients,
+        public override string Send(FormatOptions options, MimeMessage message, MailboxAddress sender, IEnumerable<MailboxAddress> recipients,
             CancellationToken cancellationToken = new CancellationToken(), ITransferProgress progress = null)
         {
             if (SendException != null) throw SendException;
+            return string.Empty;
         }
 
         /*
@@ -184,32 +186,34 @@ namespace MailMergeLib.Tests
         public override bool IsAuthenticated { get; }
         */
 
-        public override void Send(MimeMessage message, CancellationToken cancellationToken = new CancellationToken(),
+        public override string Send(MimeMessage message, CancellationToken cancellationToken = new CancellationToken(),
             ITransferProgress progress = null)
         {
             if (SendException != null) throw SendException;  // in use
+            return string.Empty;
         }
 
-        public override Task SendAsync(MimeMessage message, CancellationToken cancellationToken = new CancellationToken(),
+        public override Task<string> SendAsync(MimeMessage message, CancellationToken cancellationToken = new CancellationToken(),
             ITransferProgress progress = null)
         {
             if (SendException != null) throw SendException;
 
-            return Task.CompletedTask;
+            return Task.FromResult(string.Empty);
         }
 
-        public override void Send(MimeMessage message, MailboxAddress sender, IEnumerable<MailboxAddress> recipients,
+        public override string Send(MimeMessage message, MailboxAddress sender, IEnumerable<MailboxAddress> recipients,
             CancellationToken cancellationToken = new CancellationToken(), ITransferProgress progress = null)
         {
             if (SendException != null) throw SendException;
+            return string.Empty;
         }
 
-        public override Task SendAsync(MimeMessage message, MailboxAddress sender, IEnumerable<MailboxAddress> recipients,
+        public override Task<string> SendAsync(MimeMessage message, MailboxAddress sender, IEnumerable<MailboxAddress> recipients,
             CancellationToken cancellationToken = new CancellationToken(), ITransferProgress progress = null)
         {
             if (SendException != null) throw SendException;
 
-            return Task.CompletedTask;
+            return Task.FromResult(string.Empty);
         }
 
         protected override void OnMessageSent(MessageSentEventArgs e)

--- a/Src/MailMergeLib.Tests/MailMergeLib.Tests.csproj
+++ b/Src/MailMergeLib.Tests/MailMergeLib.Tests.csproj
@@ -36,11 +36,11 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageReference Include="Microsoft.DotNet.PlatformAbstractions" Version="3.1.6" />
-    <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="5.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />
-    <PackageReference Include="netDumbster" Version="2.0.0.7" />
-    <PackageReference Include="NUnit" Version="3.12.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="6.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
+    <PackageReference Include="netDumbster" Version="2.0.0.8" />
+    <PackageReference Include="NUnit" Version="3.13.2" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
     <PackageReference Include="System.ValueTuple" Version="4.5.0" />
   </ItemGroup>
 

--- a/Src/MailMergeLib.Tests/Settings_Serialization.cs
+++ b/Src/MailMergeLib.Tests/Settings_Serialization.cs
@@ -164,7 +164,7 @@ namespace MailMergeLib.Tests
             {
                 // An exception is thrown because username / password are saved as plain text,
                 // while with encryption enabled, both should be encrypted.
-                Assert.Throws<YAXLib.YAXPropertyCannotBeAssignedTo>(() =>
+                Assert.Throws<YAXLib.Exceptions.YAXPropertyCannotBeAssignedTo>(() =>
                     Settings.Deserialize(Path.Combine(TestFileFolders.FilesAbsPath, _settingsFilename), null));
             }
         }

--- a/Src/MailMergeLib.Tests/TestFiles/TestSettings.xml
+++ b/Src/MailMergeLib.Tests/TestFiles/TestSettings.xml
@@ -40,9 +40,9 @@
     <CharacterEncoding>utf-32</CharacterEncoding>
     <CultureInfo>de-DE</CultureInfo>
     <FileBaseDirectory>C:\Path-to-Base-Dir</FileBaseDirectory>
-    <IgnoreIllegalRecipientAddresses>False</IgnoreIllegalRecipientAddresses>
-    <IgnoreMissingInlineAttachments>True</IgnoreMissingInlineAttachments>
-    <IgnoreMissingFileAttachments>True</IgnoreMissingFileAttachments>
+    <IgnoreIllegalRecipientAddresses>false</IgnoreIllegalRecipientAddresses>
+    <IgnoreMissingInlineAttachments>true</IgnoreMissingInlineAttachments>
+    <IgnoreMissingFileAttachments>true</IgnoreMissingFileAttachments>
     <Priority>Urgent</Priority>
     <StandardFromAddress>"sender name" &lt;sender@example.com&gt;</StandardFromAddress>
     <Organization>axuno gGmbH</Organization>
@@ -51,7 +51,7 @@
       <ParseErrorAction>MaintainTokens</ParseErrorAction>
       <FormatErrorAction>OutputErrorInResult</FormatErrorAction>
       <CaseSensitivity>CaseInsensitive</CaseSensitivity>
-      <ConvertCharacterStringLiterals>True</ConvertCharacterStringLiterals>
+      <ConvertCharacterStringLiterals>true</ConvertCharacterStringLiterals>
     </SmartFormatterConfig>
   </Message>
 </MailMergeLibSettings>

--- a/Src/MailMergeLib.sln
+++ b/Src/MailMergeLib.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.28803.156
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.32014.148
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MailMergeLib.Tests", "MailMergeLib.Tests\MailMergeLib.Tests.csproj", "{89C5BF32-DA54-4BEC-93B9-83AA060A0307}"
 EndProject

--- a/Src/MailMergeLib/Credential.cs
+++ b/Src/MailMergeLib/Credential.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Net;
-using YAXLib;
+using YAXLib.Attributes;
+using YAXLib.Enums;
 
 namespace MailMergeLib
 {

--- a/Src/MailMergeLib/MailMergeAddress.cs
+++ b/Src/MailMergeLib/MailMergeAddress.cs
@@ -1,7 +1,8 @@
 using System;
 using System.Text;
 using MimeKit;
-using YAXLib;
+using YAXLib.Attributes;
+using YAXLib.Enums;
 
 namespace MailMergeLib
 {

--- a/Src/MailMergeLib/MailMergeLib.csproj
+++ b/Src/MailMergeLib/MailMergeLib.csproj
@@ -5,9 +5,9 @@
         <CurrentYear>$([System.DateTime]::Now.ToString(yyyy))</CurrentYear>
         <Copyright>© 2007-$(CurrentYear) by axuno gGmbH</Copyright>
         <AssemblyTitle>MailMergeLib</AssemblyTitle>
-        <Version>5.7.2.0</Version>
-        <AssemblyVersion>5.7.2.0</AssemblyVersion>
-        <FileVersion>5.7.2.0</FileVersion>
+        <Version>5.8.0.0</Version>
+        <AssemblyVersion>5.8.0.0</AssemblyVersion>
+        <FileVersion>5.8.0.0</FileVersion>
         <Authors>axuno gGmbH</Authors>
         <TargetFrameworks>netstandard2.1;net461;net50</TargetFrameworks>
         <DefineConstants>TRACE;DEBUG;RELEASE</DefineConstants>
@@ -15,7 +15,6 @@
         <AssemblyName>MailMergeLib</AssemblyName>
         <AssemblyOriginatorKeyFile>MailMergeLib.snk</AssemblyOriginatorKeyFile>
         <SignAssembly>true</SignAssembly>
-        <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>
         <PackageId>MailMergeLib</PackageId>
         <PackageProjectUrl>https://github.com/axuno/MailMergeLib</PackageProjectUrl>
         <PackageIcon>MailMergeLib_64x64.png</PackageIcon>
@@ -46,7 +45,7 @@ https://github.com/axuno/MailMergeLib/blob/master/ReleaseNotes.md</PackageReleas
             <!--
             Create PublicKey file: sn -p d:MailMergeLib.snk d:MailMergeLib.snk.PublicKey
             Create PublicKey:      sn -tp d:Mailmergelib.snk.PublicKey
-        -->
+            -->
             <_Parameter1>MailMergeLib.Tests, PublicKey=00240000048000009400000006020000002400005253413100040000010001007d73450c58a30b94409ec6a1ad78af1337bae462b82c80aeda1e0501506db459cd074beb94cb342a3491687e75e0143e6fce3bfa5cc3221b29017e0f4e5b116d0b135405dad460283413f75e63c6db3b1b074a16d780f013433a7b7883e9760079b6d5a41d5d9a3cff80a3b1e42b1d057c94533c978a625c3a0a933cac9ecda9</_Parameter1>
         </AssemblyAttribute>
     </ItemGroup>
@@ -54,14 +53,13 @@ https://github.com/axuno/MailMergeLib/blob/master/ReleaseNotes.md</PackageReleas
     <ItemGroup>
         <PackageReference Include="AngleSharp" Version="0.16.1" />
         <PackageReference Include="MailKit" Version="3.1.1" />
+        <PackageReference Include="MimeKit" Version="3.1.1" />
+        <PackageReference Include="SmartFormat.NET" Version="2.7.2" />
+        <PackageReference Include="YAXLib" Version="3.0.1" />
         <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="MimeKit" Version="3.1.1" />
-        <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
-        <PackageReference Include="SmartFormat.NET" Version="2.7.2" />
-        <PackageReference Include="YAXLib" Version="3.0.1" />
     </ItemGroup>
 
     <ItemGroup Condition=" '$(TargetFramework)' == 'net461' ">

--- a/Src/MailMergeLib/MailMergeLib.csproj
+++ b/Src/MailMergeLib/MailMergeLib.csproj
@@ -24,7 +24,7 @@
         <PackageReleaseNotes>See the change log with links to the Wiki for details of this release:
 https://github.com/axuno/MailMergeLib/blob/master/ReleaseNotes.md</PackageReleaseNotes>
         <PackageTags>smtp mime mail email merge template netcore netstandard netframework net50 c#</PackageTags>
-        <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
+        <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder)</AllowedOutputExtensionsInPackageBuildOutputFolder>
         <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
         <RootNamespace>MailMergeLib</RootNamespace>
         <LangVersion>latest</LangVersion>

--- a/Src/MailMergeLib/MailMergeLib.csproj
+++ b/Src/MailMergeLib/MailMergeLib.csproj
@@ -64,14 +64,8 @@ https://github.com/axuno/MailMergeLib/blob/master/ReleaseNotes.md</PackageReleas
     <PackageReference Include="YAXLib" Version="3.0.1" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net46' ">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net461' ">
     <Reference Include="System.Configuration" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <Reference Include="System.Configuration">
-      <HintPath>C:\Program Files (x86)\Reference Assemblies\Microsoft\Framework\.NETFramework\v4.6.1\System.Configuration.dll</HintPath>
-    </Reference>
   </ItemGroup>
 
     <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">

--- a/Src/MailMergeLib/MailMergeLib.csproj
+++ b/Src/MailMergeLib/MailMergeLib.csproj
@@ -1,72 +1,76 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <Description>MailMergeLib is a mail message client library which provides comfortable mail merge capabilities for text, inline images and attachments, as well as good throughput and fault tolerance for sending mail messages.</Description>
-	<CurrentYear>$([System.DateTime]::Now.ToString(yyyy))</CurrentYear>
-    <Copyright>© 2007-$(CurrentYear) by axuno gGmbH</Copyright>
-    <AssemblyTitle>MailMergeLib</AssemblyTitle>
-    <Version>5.7.2.0</Version>
-    <AssemblyVersion>5.7.2.0</AssemblyVersion>
-    <FileVersion>5.7.2.0</FileVersion>
-    <Authors>axuno gGmbH</Authors>
-    <TargetFrameworks>netstandard2.1;net461;net50</TargetFrameworks>
-    <DefineConstants>TRACE;DEBUG;RELEASE</DefineConstants>
-    <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <AssemblyName>MailMergeLib</AssemblyName>
-    <AssemblyOriginatorKeyFile>MailMergeLib.snk</AssemblyOriginatorKeyFile>
-    <SignAssembly>true</SignAssembly>
-    <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>
-    <PackageId>MailMergeLib</PackageId>
-    <PackageProjectUrl>https://github.com/axuno/MailMergeLib</PackageProjectUrl>
-    <PackageIconUrl>https://github.com/axuno/MailMergeLib/raw/master/MailMergeLib_64x64.png</PackageIconUrl>
-    <PackageLicenseUrl></PackageLicenseUrl>
-    <RepositoryUrl>https://github.com/axuno/MailMergeLib</RepositoryUrl>
-    <PackageReleaseNotes>See the change log with links to the Wiki for details of this release:
+    <PropertyGroup>
+        <Description>MailMergeLib is a mail message client library which provides comfortable mail merge capabilities for text, inline images and attachments, as well as good throughput and fault tolerance for sending mail messages.</Description>
+        <CurrentYear>$([System.DateTime]::Now.ToString(yyyy))</CurrentYear>
+        <Copyright>© 2007-$(CurrentYear) by axuno gGmbH</Copyright>
+        <AssemblyTitle>MailMergeLib</AssemblyTitle>
+        <Version>5.7.2.0</Version>
+        <AssemblyVersion>5.7.2.0</AssemblyVersion>
+        <FileVersion>5.7.2.0</FileVersion>
+        <Authors>axuno gGmbH</Authors>
+        <TargetFrameworks>netstandard2.1;net461;net50</TargetFrameworks>
+        <DefineConstants>TRACE;DEBUG;RELEASE</DefineConstants>
+        <GenerateDocumentationFile>true</GenerateDocumentationFile>
+        <AssemblyName>MailMergeLib</AssemblyName>
+        <AssemblyOriginatorKeyFile>MailMergeLib.snk</AssemblyOriginatorKeyFile>
+        <SignAssembly>true</SignAssembly>
+        <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>
+        <PackageId>MailMergeLib</PackageId>
+        <PackageProjectUrl>https://github.com/axuno/MailMergeLib</PackageProjectUrl>
+        <PackageIcon>MailMergeLib_64x64.png</PackageIcon>
+        <PackageLicenseUrl></PackageLicenseUrl>
+        <RepositoryUrl>https://github.com/axuno/MailMergeLib</RepositoryUrl>
+        <PackageReleaseNotes>See the change log with links to the Wiki for details of this release:
 https://github.com/axuno/MailMergeLib/blob/master/ReleaseNotes.md</PackageReleaseNotes>
-    <PackageTags>smtp mime mail email merge template netcore netstandard netframework net50 c#</PackageTags>
-    <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
-    <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
-    <RootNamespace>MailMergeLib</RootNamespace>
-    <LangVersion>latest</LangVersion>
-    <PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <RepositoryType>Git</RepositoryType>
-  </PropertyGroup>
+        <PackageTags>smtp mime mail email merge template netcore netstandard netframework net50 c#</PackageTags>
+        <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
+        <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
+        <RootNamespace>MailMergeLib</RootNamespace>
+        <LangVersion>latest</LangVersion>
+        <PackageLicenseExpression>MIT</PackageLicenseExpression>
+        <RepositoryType>Git</RepositoryType>
+    </PropertyGroup>
 
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <DebugSymbols>true</DebugSymbols>
-    <DebugType>portable</DebugType>
-    <Optimize>false</Optimize>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>3</WarningLevel>
-    <PlatformTarget>AnyCPU</PlatformTarget>
-  </PropertyGroup>
+    <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+        <DebugSymbols>true</DebugSymbols>
+        <DebugType>portable</DebugType>
+        <Optimize>false</Optimize>
+        <ErrorReport>prompt</ErrorReport>
+        <WarningLevel>3</WarningLevel>
+        <PlatformTarget>AnyCPU</PlatformTarget>
+    </PropertyGroup>
 
-  <ItemGroup>
-    <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute">
-        <!--
+    <ItemGroup>
+        <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute">
+            <!--
             Create PublicKey file: sn -p d:MailMergeLib.snk d:MailMergeLib.snk.PublicKey
             Create PublicKey:      sn -tp d:Mailmergelib.snk.PublicKey
         -->
-        <_Parameter1>MailMergeLib.Tests, PublicKey=00240000048000009400000006020000002400005253413100040000010001007d73450c58a30b94409ec6a1ad78af1337bae462b82c80aeda1e0501506db459cd074beb94cb342a3491687e75e0143e6fce3bfa5cc3221b29017e0f4e5b116d0b135405dad460283413f75e63c6db3b1b074a16d780f013433a7b7883e9760079b6d5a41d5d9a3cff80a3b1e42b1d057c94533c978a625c3a0a933cac9ecda9</_Parameter1>
-    </AssemblyAttribute>
-  </ItemGroup>
+            <_Parameter1>MailMergeLib.Tests, PublicKey=00240000048000009400000006020000002400005253413100040000010001007d73450c58a30b94409ec6a1ad78af1337bae462b82c80aeda1e0501506db459cd074beb94cb342a3491687e75e0143e6fce3bfa5cc3221b29017e0f4e5b116d0b135405dad460283413f75e63c6db3b1b074a16d780f013433a7b7883e9760079b6d5a41d5d9a3cff80a3b1e42b1d057c94533c978a625c3a0a933cac9ecda9</_Parameter1>
+        </AssemblyAttribute>
+    </ItemGroup>
 
-  <ItemGroup>
-    <PackageReference Include="AngleSharp" Version="0.16.1" />
-    <PackageReference Include="MailKit" Version="3.1.1" />
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-    <PackageReference Include="MimeKit" Version="3.1.1" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
-    <PackageReference Include="SmartFormat.NET" Version="2.7.2" />
-    <PackageReference Include="YAXLib" Version="3.0.1" />
-  </ItemGroup>
+    <ItemGroup>
+        <PackageReference Include="AngleSharp" Version="0.16.1" />
+        <PackageReference Include="MailKit" Version="3.1.1" />
+        <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1">
+            <PrivateAssets>all</PrivateAssets>
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
+        <PackageReference Include="MimeKit" Version="3.1.1" />
+        <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+        <PackageReference Include="SmartFormat.NET" Version="2.7.2" />
+        <PackageReference Include="YAXLib" Version="3.0.1" />
+    </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net461' ">
-    <Reference Include="System.Configuration" />
-  </ItemGroup>
+    <ItemGroup Condition=" '$(TargetFramework)' == 'net461' ">
+        <Reference Include="System.Configuration" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <None Include="../../MailMergeLib_64x64.png" Pack="true" Visible="false" PackagePath="/" />
+    </ItemGroup>
 
     <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
         <OutputPath>bin\Release\</OutputPath>

--- a/Src/MailMergeLib/MailMergeLib.csproj
+++ b/Src/MailMergeLib/MailMergeLib.csproj
@@ -2,13 +2,14 @@
 
   <PropertyGroup>
     <Description>MailMergeLib is a mail message client library which provides comfortable mail merge capabilities for text, inline images and attachments, as well as good throughput and fault tolerance for sending mail messages.</Description>
-    <Copyright>© 2007-2021 by axuno gGmbH</Copyright>
+	<CurrentYear>$([System.DateTime]::Now.ToString(yyyy))</CurrentYear>
+    <Copyright>© 2007-$(CurrentYear) by axuno gGmbH</Copyright>
     <AssemblyTitle>MailMergeLib</AssemblyTitle>
-    <Version>5.7.1.0</Version>
-    <AssemblyVersion>5.7.1.0</AssemblyVersion>
-    <FileVersion>5.7.1.0</FileVersion>
+    <Version>5.7.2.0</Version>
+    <AssemblyVersion>5.7.2.0</AssemblyVersion>
+    <FileVersion>5.7.2.0</FileVersion>
     <Authors>axuno gGmbH</Authors>
-    <TargetFrameworks>netstandard2.1;net46;net50</TargetFrameworks>
+    <TargetFrameworks>netstandard2.1;net461;net50</TargetFrameworks>
     <DefineConstants>TRACE;DEBUG;RELEASE</DefineConstants>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <AssemblyName>MailMergeLib</AssemblyName>
@@ -51,20 +52,26 @@ https://github.com/axuno/MailMergeLib/blob/master/ReleaseNotes.md</PackageReleas
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="AngleSharp" Version="0.13.0" />
-    <PackageReference Include="MailKit" Version="2.4.1" />
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0">
+    <PackageReference Include="AngleSharp" Version="0.16.1" />
+    <PackageReference Include="MailKit" Version="3.1.1" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="MimeKit" Version="2.4.1" />
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
-    <PackageReference Include="SmartFormat.NET" Version="2.5.0" />
-    <PackageReference Include="YAXLib" Version="2.15.0" />
+    <PackageReference Include="MimeKit" Version="3.1.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+    <PackageReference Include="SmartFormat.NET" Version="2.7.2" />
+    <PackageReference Include="YAXLib" Version="3.0.1" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net46' ">
     <Reference Include="System.Configuration" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Reference Include="System.Configuration">
+      <HintPath>C:\Program Files (x86)\Reference Assemblies\Microsoft\Framework\.NETFramework\v4.6.1\System.Configuration.dll</HintPath>
+    </Reference>
   </ItemGroup>
 
     <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">

--- a/Src/MailMergeLib/MailMergeMessage.cs
+++ b/Src/MailMergeLib/MailMergeMessage.cs
@@ -983,6 +983,14 @@ namespace MailMergeLib
             return Equals((MailMergeMessage)obj);
         }
 
+        /// <inheritdoc/>
+        public override int GetHashCode() {
+            unchecked
+            {
+                return Serialize().GetHashCode();
+            }
+        }
+
         /// <summary>
         /// Compares the MailMergeMessage with an other instance of MailMergeMessage for equality.
         /// </summary>

--- a/Src/MailMergeLib/MailMergeMessage.cs
+++ b/Src/MailMergeLib/MailMergeMessage.cs
@@ -9,7 +9,8 @@ using MailMergeLib.Serialization;
 using SmartFormat.Extensions;
 using MailMergeLib.Templates;
 using MimeKit;
-using YAXLib;
+using YAXLib.Attributes;
+using YAXLib.Enums;
 
 namespace MailMergeLib
 {

--- a/Src/MailMergeLib/MessageConfig.cs
+++ b/Src/MailMergeLib/MessageConfig.cs
@@ -3,7 +3,8 @@ using System.Globalization;
 using System.IO;
 using System.Text;
 using MimeKit;
-using YAXLib;
+using YAXLib.Attributes;
+using YAXLib.Enums;
 
 namespace MailMergeLib
 {

--- a/Src/MailMergeLib/MessageStore/FileMessageStore.cs
+++ b/Src/MailMergeLib/MessageStore/FileMessageStore.cs
@@ -3,7 +3,8 @@ using System.IO;
 using System.Linq;
 using System.Text;
 using MailMergeLib.Serialization;
-using YAXLib;
+using YAXLib.Attributes;
+using YAXLib.Enums;
 
 namespace MailMergeLib.MessageStore
 {

--- a/Src/MailMergeLib/MessageStore/MessageInfo.cs
+++ b/Src/MailMergeLib/MessageStore/MessageInfo.cs
@@ -1,5 +1,6 @@
 ﻿using MailMergeLib.Serialization;
-using YAXLib;
+using YAXLib.Attributes;
+using YAXLib.Enums;
 
 namespace MailMergeLib.MessageStore
 {

--- a/Src/MailMergeLib/SenderConfig.cs
+++ b/Src/MailMergeLib/SenderConfig.cs
@@ -1,5 +1,6 @@
 ﻿using System.Linq;
-using YAXLib;
+using YAXLib.Attributes;
+using YAXLib.Enums;
 
 namespace MailMergeLib
 {

--- a/Src/MailMergeLib/Serialization/PartSerializer.cs
+++ b/Src/MailMergeLib/Serialization/PartSerializer.cs
@@ -2,6 +2,7 @@ using System;
 using System.Xml.Linq;
 using MailMergeLib.Templates;
 using YAXLib;
+using YAXLib.Exceptions;
 
 namespace MailMergeLib.Serialization
 {

--- a/Src/MailMergeLib/Serialization/SerializationFactory.cs
+++ b/Src/MailMergeLib/Serialization/SerializationFactory.cs
@@ -2,6 +2,8 @@
 using System.IO;
 using System.Text;
 using YAXLib;
+using YAXLib.Enums;
+using YAXLib.Options;
 
 namespace MailMergeLib.Serialization
 {
@@ -27,8 +29,14 @@ namespace MailMergeLib.Serialization
         /// <returns>Returns a pre-configured YAXSerializer.</returns>
         internal static YAXSerializer GetStandardSerializer (Type classType)
         {
-            return new YAXSerializer(classType, YAXExceptionHandlingPolicies.ThrowErrorsOnly, YAXExceptionTypes.Error,
-                YAXSerializationOptions.SerializeNullObjects) {MaxRecursion = 50};
+            return new YAXSerializer(classType,
+                new SerializerOptions
+                {
+                    ExceptionHandlingPolicies = YAXExceptionHandlingPolicies.ThrowErrorsOnly,
+                    ExceptionBehavior = YAXExceptionTypes.Error,
+                    MaxRecursion = 50,
+                    SerializationOptions = YAXSerializationOptions.SerializeNullObjects
+                });
         }
         
         /// <summary>

--- a/Src/MailMergeLib/Settings.cs
+++ b/Src/MailMergeLib/Settings.cs
@@ -1,7 +1,8 @@
 ﻿using System.IO;
 using System.Text;
 using MailMergeLib.Serialization;
-using YAXLib;
+using YAXLib.Attributes;
+using YAXLib.Enums;
 
 namespace MailMergeLib
 {

--- a/Src/MailMergeLib/SmtpClientConfig.cs
+++ b/Src/MailMergeLib/SmtpClientConfig.cs
@@ -6,7 +6,8 @@ using MailKit.Security;
 using System.Security.Cryptography.X509Certificates;
 using System.Security.Authentication;
 using MailMergeLib.Serialization;
-using YAXLib;
+using YAXLib.Attributes;
+using YAXLib.Enums;
 #if NETFRAMEWORK
 using System.Configuration;
 using System.Net.Configuration;

--- a/Src/MailMergeLib/Templates/Part.cs
+++ b/Src/MailMergeLib/Templates/Part.cs
@@ -1,5 +1,5 @@
 ﻿using MailMergeLib.Serialization;
-using YAXLib;
+using YAXLib.Attributes;
 
 namespace MailMergeLib.Templates
 {

--- a/Src/MailMergeLib/Templates/Template.cs
+++ b/Src/MailMergeLib/Templates/Template.cs
@@ -1,6 +1,7 @@
 using System.Collections.Specialized;
 using System.Linq;
-using YAXLib;
+using YAXLib.Attributes;
+using YAXLib.Enums;
 
 namespace MailMergeLib.Templates
 {

--- a/Src/MailMergeLib/Templates/Templates.cs
+++ b/Src/MailMergeLib/Templates/Templates.cs
@@ -3,7 +3,7 @@ using System.IO;
 using System.Linq;
 using System.Text;
 using MailMergeLib.Serialization;
-using YAXLib;
+using YAXLib.Attributes;
 
 namespace MailMergeLib.Templates
 {

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -22,7 +22,8 @@ for:
       - ps: dotnet --version
       - ps: dotnet restore --verbosity quiet
       - ps: dotnet add .\MailMergeLib.Tests\MailMergeLib.Tests.csproj package AltCover
-      - ps: dotnet build MailMergeLib.sln /verbosity:minimal /t:rebuild /p:configuration=release /nowarn:CS1591,CS0618
+      - ps: dotnet build MailMergeLib.sln /verbosity:minimal /t:rebuild /p:configuration=release /p:IncludeSymbols=true /p:ContinuousIntegrationBuild=true /nowarn:CS1591,CS0618
+      - ps: dotnet pack MailMergeLib.sln --verbosity minimal --configuration release /p:IncludeSymbols=true /p:SymbolPackageFormat=snupkg /p:PackageOutputPath=../../artifacts /p:ContinuousIntegrationBuild=true
     test_script:
       - cmd: nuget install Appveyor.TestLogger
       - cmd: dotnet test --no-build --framework netcoreapp3.1 --test-adapter-path:. --logger:Appveyor MailMergeLib.sln /p:configuration=release /p:AltCover=true /p:AltCoverXmlReport="coverage.xml" /p:AltCover=true /p:AltCoverStrongNameKey="..\MailMergeLib\MailMergeLib.snk" /p:AltCoverAssemblyExcludeFilter="MailMergeLib.Tests|NUnit3.TestAdapter" /p:AltCoverLineCover="true"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -23,12 +23,17 @@ for:
       - ps: dotnet restore --verbosity quiet
       - ps: dotnet add .\MailMergeLib.Tests\MailMergeLib.Tests.csproj package AltCover
       - ps: dotnet build MailMergeLib.sln /verbosity:minimal /t:rebuild /p:configuration=release /p:IncludeSymbols=true /p:ContinuousIntegrationBuild=true /nowarn:CS1591,CS0618
-      - ps: dotnet pack MailMergeLib.sln --verbosity minimal --configuration release /p:IncludeSymbols=true /p:SymbolPackageFormat=snupkg /p:PackageOutputPath=../../artifacts /p:ContinuousIntegrationBuild=true
+      - ps: dotnet pack MailMergeLib.sln --verbosity minimal --configuration release /p:IncludeSymbols=true /p:SymbolPackageFormat=snupkg /p:PackageOutputPath=$env:APPVEYOR_BUILD_FOLDER/artifacts /p:ContinuousIntegrationBuild=true
     test_script:
       - cmd: nuget install Appveyor.TestLogger
       - cmd: dotnet test --no-build --framework netcoreapp3.1 --test-adapter-path:. --logger:Appveyor MailMergeLib.sln /p:configuration=release /p:AltCover=true /p:AltCoverXmlReport="coverage.xml" /p:AltCover=true /p:AltCoverStrongNameKey="..\MailMergeLib\MailMergeLib.snk" /p:AltCoverAssemblyExcludeFilter="MailMergeLib.Tests|NUnit3.TestAdapter" /p:AltCoverLineCover="true"
       - cmd: nuget install codecov -excludeversion
       - cmd: .\Codecov\Tools\win7-x86\codecov.exe -f ".\MailMergeLib.Tests\coverage.netcoreapp3.1.xml" -n netcoreapp3.1win
+    artifacts:
+      - path: 'artifacts\*.nupkg'
+        type: NuGetPackage
+      - path: 'artifacts\*.snupkg'
+        type: NuGetPackage
   -
     matrix:
       only:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-version: 5.7.1.{build}
+version: 5.7.2.{build}
 environment:
   DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true 
   matrix:
@@ -39,6 +39,5 @@ for:
       - dotnet add ./MailMergeLib.Tests/MailMergeLib.Tests.csproj package AltCover
       - dotnet build MailMergeLib.sln /verbosity:minimal /t:rebuild /p:configuration=release /nowarn:CS1591,CS0618 
     test_script:
-      - nuget install Appveyor.TestLogger
       - dotnet test --no-build --framework netcoreapp3.1 MailMergeLib.sln /p:configuration=release /p:AltCover=true /p:AltCoverXmlReport="coverage.xml" /p:AltCover=true /p:AltCoverStrongNameKey="../MailMergeLib/MailMergeLib.snk" /p:AltCoverAssemblyExcludeFilter="MailMergeLib.Tests|NUnit3.TestAdapter" /p:AltCoverLineCover="true"
       - bash <(curl -s https://codecov.io/bash) -f ./MailMergeLib.Tests/coverage.netcoreapp3.1.xml -n netcoreapp3.1linux

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-version: 5.7.2.{build}
+version: 5.8.0.{build}
 environment:
   DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true 
   matrix:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,7 +3,7 @@ environment:
   DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true 
   matrix:
   - job_name: windows
-    appveyor_build_worker_image: Visual Studio 2019
+    appveyor_build_worker_image: Visual Studio 2022
   - job_name: linux
     appveyor_build_worker_image: Ubuntu
 matrix:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -40,5 +40,5 @@ for:
       - dotnet build MailMergeLib.sln /verbosity:minimal /t:rebuild /p:configuration=release /nowarn:CS1591,CS0618 
     test_script:
       - nuget install Appveyor.TestLogger
-      - dotnet test --no-build --framework netcoreapp3.1 --test-adapter-path:. --logger:Appveyor MailMergeLib.sln /p:configuration=release /p:AltCover=true /p:AltCoverXmlReport="coverage.xml" /p:AltCover=true /p:AltCoverStrongNameKey="../MailMergeLib/MailMergeLib.snk" /p:AltCoverAssemblyExcludeFilter="MailMergeLib.Tests|NUnit3.TestAdapter" /p:AltCoverLineCover="true"
+      - dotnet test --no-build --framework netcoreapp3.1 MailMergeLib.sln /p:configuration=release /p:AltCover=true /p:AltCoverXmlReport="coverage.xml" /p:AltCover=true /p:AltCoverStrongNameKey="../MailMergeLib/MailMergeLib.snk" /p:AltCoverAssemblyExcludeFilter="MailMergeLib.Tests|NUnit3.TestAdapter" /p:AltCoverLineCover="true"
       - bash <(curl -s https://codecov.io/bash) -f ./MailMergeLib.Tests/coverage.netcoreapp3.1.xml -n netcoreapp3.1linux


### PR DESCRIPTION
* Updated dependencies to latest versions
  * Fixed compatibility issues with updated dependencies (specifically `MailKit`, `MimeKit` and `YAXLib` with new major versions).
  * Now referencing updated [SmartFormat.Net v2.7.2](https://github.com/axuno/SmartFormat) for formatting.
  * No impact on `MailMergeLib` public API.
* Supported frameworks
  * .Net Framework: 4.6.1 and later
  * NetStandard: 2.1 and later