### PR TITLE
Bugfix: UriFormatException while processing embedded images

### DIFF
--- a/Src/MailMergeLib.Tests/HtmlBodyBuilderTest.cs
+++ b/Src/MailMergeLib.Tests/HtmlBodyBuilderTest.cs
@@ -65,7 +65,7 @@ namespace MailMergeLib.Tests
         [Test]
         public void EmbeddedDataImage_ShouldNotBeTouched()
         {
-            var image = "data:image/png;base64,\r\niVBORw0KGgoAAAANSUhEUgAAAAEAAAAKAQMAAABPHKYJAAAABGdBTUEAALGPC/xhBQAAAAZQTFRFB\r\nPl7AAAAx+zuaAAAAAd0SU1FB9MEFwMzHmwS680AAAALSURBVBjTY2DABAAAFAABQpvU+wAAAABJRU\r\n5ErkJggg==";
+            var image = "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAAKAQMAAABPHKYJAAAABGdBTUEAALGPC/xhBQAAAAZQTFRFBPl7AAAAx+zuaAAAAAd0SU1FB9MEFwMzHmwS680AAAALSURBVBjTY2DABAAAFAABQpvU+wAAAABJRU5ErkJggg==";
             var imageTag = $"<img width=\"10\" height=\"10\" alt=\"1Pixel\" src=\"{image}\">";
             var mmm = new MailMergeMessage("", "plain text",
                 $"<html><body>{imageTag}</body></html>");
@@ -81,7 +81,7 @@ namespace MailMergeLib.Tests
             // if the embedded image was processed with new Uri(...)
             
             // Note: No need to be valid Base64 here:
-            var image = "data:image/png;base64,\r\n" + new string('a', 0xFFF0 + 1);
+            var image = "data:image/png;base64," + new string('a', 0xFFF0 + 1);
             var imageTag = $"<img width=\"10\" height=\"10\" alt=\"1Pixel\" src=\"{image}\">";
             var mmm = new MailMergeMessage("", "plain text",
                 $"<html><body>{imageTag}</body></html>");

--- a/Src/MailMergeLib.Tests/HtmlBodyBuilderTest.cs
+++ b/Src/MailMergeLib.Tests/HtmlBodyBuilderTest.cs
@@ -61,5 +61,32 @@ namespace MailMergeLib.Tests
             var html = hbb.GetBodyPart();
             Assert.IsTrue(!html.ToString().Contains(subjectToSet));
         }
+
+        [Test]
+        public void EmbeddedDataImage_ShouldNotBeTouched()
+        {
+            var image = "data:image/png;base64,\r\niVBORw0KGgoAAAANSUhEUgAAAAEAAAAKAQMAAABPHKYJAAAABGdBTUEAALGPC/xhBQAAAAZQTFRFB\r\nPl7AAAAx+zuaAAAAAd0SU1FB9MEFwMzHmwS680AAAALSURBVBjTY2DABAAAFAABQpvU+wAAAABJRU\r\n5ErkJggg==";
+            var imageTag = $"<img width=\"10\" height=\"10\" alt=\"1Pixel\" src=\"{image}\">";
+            var mmm = new MailMergeMessage("", "plain text",
+                $"<html><body>{imageTag}</body></html>");
+            var hbb = new HtmlBodyBuilder(mmm, (object) null);
+            var html = hbb.GetBodyPart();
+            Assert.That(html.ToString(), Does.Contain(imageTag));
+        }
+
+        [Test]
+        public void LargeEmbeddedDataImage_ShouldNotThrow()
+        {
+            // Exceeding Uri size of 0xFFF0 would throw an UriFormatException,
+            // if the embedded image was processed with new Uri(...)
+            
+            // Note: No need to be valid Base64 here:
+            var image = "data:image/png;base64,\r\n" + new string('a', 0xFFF0 + 1);
+            var imageTag = $"<img width=\"10\" height=\"10\" alt=\"1Pixel\" src=\"{image}\">";
+            var mmm = new MailMergeMessage("", "plain text",
+                $"<html><body>{imageTag}</body></html>");
+            var hbb = new HtmlBodyBuilder(mmm, (object) null);
+            Assert.That(code: () => hbb.GetBodyPart(), Throws.Nothing);
+        }
     }
 }

--- a/Src/MailMergeLib.Tests/MailMergeLib.Tests.csproj
+++ b/Src/MailMergeLib.Tests/MailMergeLib.Tests.csproj
@@ -2,10 +2,11 @@
 
   <PropertyGroup>
     <Description>MailMergeLib is a mail message client library which provides comfortable mail merge capabilities for text, inline images and attachments, as well as good throughput and fault tolerance for sending mail messages.</Description>
-    <Copyright>© 2007-2021 by axuno gGmbH</Copyright>
+    <CurrentYear>$([System.DateTime]::Now.ToString(yyyy))</CurrentYear>
+    <Copyright>© 2007-$(CurrentYear) by axuno gGmbH</Copyright>
     <AssemblyTitle>MailMergeLib.UnitTest</AssemblyTitle>
     <Authors>axuno gGmbH</Authors>
-    <Version>5.7.1.0</Version>
+    <Version>5.8.0.0</Version>
     <TargetFrameworks>netcoreapp3.1;net461</TargetFrameworks>
     <DefineConstants>$(DefineConstants)</DefineConstants>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>

--- a/Src/MailMergeLib/HtmlBodyBuilder.cs
+++ b/Src/MailMergeLib/HtmlBodyBuilder.cs
@@ -192,7 +192,7 @@ namespace MailMergeLib
 
                 // img src is not a local file (e.g. starting with "http" or is embedded base64 image), or manually included cid reference
                 // so we just save the value with placeholders replaced
-                if (string.IsNullOrEmpty(currSrc) || (currSrcUri.Scheme != UriScheme.File) || currSrc.StartsWith("cid:", StringComparison.OrdinalIgnoreCase)) {
+                if (string.IsNullOrEmpty(currSrc) || (currSrcUri.Scheme != UriScheme.File) || currSrc.StartsWith("cid:", StringComparison.OrdinalIgnoreCase)) 
                 {
                     // leave img.Attributes["src"].Value as it is
                     continue;

--- a/Src/MailMergeLib/HtmlBodyBuilder.cs
+++ b/Src/MailMergeLib/HtmlBodyBuilder.cs
@@ -180,7 +180,10 @@ namespace MailMergeLib
             {
                 var img = (IHtmlImageElement)element;
                 var currSrc = img.Attributes["src"]?.Value?.Trim();
-                if (currSrc == null) continue;
+                if (currSrc == null || currSrc.StartsWith("data:image", StringComparison.OrdinalIgnoreCase)) 
+                {
+                    continue;
+                }
 
                 // replace any placeholders with variables
                 currSrc = _mailMergeMessage.SearchAndReplaceVars(currSrc, _dataItem);
@@ -189,8 +192,7 @@ namespace MailMergeLib
 
                 // img src is not a local file (e.g. starting with "http" or is embedded base64 image), or manually included cid reference
                 // so we just save the value with placeholders replaced
-                if (string.IsNullOrEmpty(currSrc) || (currSrcUri.Scheme != UriScheme.File) ||
-                    currSrc.StartsWith("data:image", StringComparison.OrdinalIgnoreCase) || currSrc.StartsWith("cid:", StringComparison.OrdinalIgnoreCase))
+                if (string.IsNullOrEmpty(currSrc) || (currSrcUri.Scheme != UriScheme.File) || currSrc.StartsWith("cid:", StringComparison.OrdinalIgnoreCase)) {
                 {
                     // leave img.Attributes["src"].Value as it is
                     continue;

--- a/Src/MailMergeLib/HtmlBodyBuilder.cs
+++ b/Src/MailMergeLib/HtmlBodyBuilder.cs
@@ -151,10 +151,9 @@ namespace MailMergeLib
         /// </summary>
         public string DocBaseUri
         {
-            set
-            {
-                _docBaseUri = new Uri(string.IsNullOrEmpty(value) ? string.Concat(UriScheme.File, UriScheme.SchemeDelimiter) : value); 
-            }
+            set => _docBaseUri = new Uri(string.IsNullOrEmpty(value)
+                ? string.Concat(UriScheme.File, UriScheme.SchemeDelimiter)
+                : value);
             get => _docBaseUri.ToString();
         }
 
@@ -170,6 +169,9 @@ namespace MailMergeLib
 
         /// <summary>
         /// Converts the SRC attribute of IMG tags into embedded content ids (cid).
+        /// <para>
+        /// Note: Embedded images or existing (manually added) cid references will not be touched.
+        /// </para>
         /// Example: &lt;img src="filename.jpg" /&lt; becomes &lt;img src="cid:unique-cid-jpg" /&lt;
         /// </summary>
         private void ReplaceImgSrcByCid()
@@ -179,27 +181,35 @@ namespace MailMergeLib
             foreach (var element in _htmlDocument.All.Where(m => m is IHtmlImageElement))
             {
                 var img = (IHtmlImageElement)element;
-                var currSrc = img.Attributes["src"]?.Value?.Trim();
-                if (currSrc == null || currSrc.StartsWith("data:image", StringComparison.OrdinalIgnoreCase)) 
+                var srcAttr = img.Attributes["src"];
+                if (srcAttr is null) continue;
+
+                var srcAttrValue = srcAttr.Value.Trim();
+                
+                // Skip embedded base64 image, or manually included cid reference
+                if (string.IsNullOrEmpty(srcAttrValue) 
+                    || srcAttrValue.StartsWith("data:image", StringComparison.OrdinalIgnoreCase)
+                    || srcAttrValue.StartsWith("cid:", StringComparison.OrdinalIgnoreCase))
                 {
                     continue;
                 }
 
                 // replace any placeholders with variables
-                currSrc = _mailMergeMessage.SearchAndReplaceVars(currSrc, _dataItem);
-                // Note: if currSrc is a rooted path, _docBaseUrl will be ignored
-                var currSrcUri = new Uri(_docBaseUri, currSrc);
+                srcAttrValue = _mailMergeMessage.SearchAndReplaceVars(srcAttrValue, _dataItem);
 
-                // img src is not a local file (e.g. starting with "http" or is embedded base64 image), or manually included cid reference
+                // Note: if srcAttrValue is a rooted path, _docBaseUrl will be ignored
+                var srcUri = new Uri(_docBaseUri, srcAttrValue);
+
+                // img src is not a local file 
                 // so we just save the value with placeholders replaced
-                if (string.IsNullOrEmpty(currSrc) || (currSrcUri.Scheme != UriScheme.File) || currSrc.StartsWith("cid:", StringComparison.OrdinalIgnoreCase)) 
+                if (srcUri.Scheme != UriScheme.File) 
                 {
                     // leave img.Attributes["src"].Value as it is
                     continue;
                 }
 
                 // this will succeed only with local files (at this time, they don't need to exist yet)
-                var filename = _mailMergeMessage.SearchAndReplaceVarsInFilename(currSrcUri.LocalPath, _dataItem);
+                var filename = _mailMergeMessage.SearchAndReplaceVarsInFilename(srcUri.LocalPath, _dataItem);
                 try
                 {
                     if (!fileList.ContainsKey(filename))
@@ -208,14 +218,14 @@ namespace MailMergeLib
                         var contentType = MimeTypes.GetMimeType(filename);
                         var cid = MimeUtils.GenerateMessageId();
                         InlineAtt.Add(new FileAttachment(fileInfo.FullName, MakeCid(string.Empty, cid, fileInfo.Extension), contentType));
-                        img.Attributes["src"].Value = MakeCid("cid:", cid, fileInfo.Extension);
+                        srcAttr.Value = MakeCid("cid:", cid, fileInfo.Extension);
                         fileList.Add(fileInfo.FullName, cid);
                     }
                     else
                     {
                         var cidForExistingFile = fileList[filename];
                         var fileInfo = new FileInfo(filename);
-                        img.Attributes["src"].Value = MakeCid("cid:", cidForExistingFile, fileInfo.Extension);
+                        srcAttr.Value = MakeCid("cid:", cidForExistingFile, fileInfo.Extension);
                     }
                 }
                 catch


### PR DESCRIPTION
Prevent UriFormatException ("Invalid URI: The uri string is too long") in HTML mails while processing embedded image (based64).