### PR TITLE
Bumped version to v5.8.2

### DIFF
--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -1,3 +1,7 @@
+# 5.8.2
+
+* Package references: Set highest major version of compatible dependencies for `MailKit`, `MimeKit`, `SmartFormat.NET`, `YAXLib`
+
 # 5.8.1
 
 * Fixed: Large embedded images could throw `UriFormatException` (thanks to [PhnXnhP](https://github.com/PhnXnhP))

--- a/Src/MailMergeLib/MailMergeLib.csproj
+++ b/Src/MailMergeLib/MailMergeLib.csproj
@@ -55,10 +55,10 @@ https://github.com/axuno/MailMergeLib/blob/main/ReleaseNotes.md</PackageReleaseN
 
     <ItemGroup>
         <PackageReference Include="AngleSharp" Version="0.16.1" />
-        <PackageReference Include="MailKit" Version="[3.0,4.0)" />
-        <PackageReference Include="MimeKit" Version="[3.0,4.0)" />
-        <PackageReference Include="SmartFormat.NET" Version="[2.5.0,2.7.2]" />
-        <PackageReference Include="YAXLib" Version="[3.0,4.0)" />
+        <PackageReference Include="MailKit" Version="3.*" />
+        <PackageReference Include="MimeKit" Version="3.*" />
+        <PackageReference Include="SmartFormat.NET" Version="2.*" />
+        <PackageReference Include="YAXLib" Version="3.*" />
         <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -27,7 +27,7 @@ for:
       - ps: dotnet restore --verbosity quiet
       - ps: dotnet add .\MailMergeLib.Tests\MailMergeLib.Tests.csproj package AltCover
       - ps: |
-          $version = "5.8.1"
+          $version = "5.8.2"
           $versionFile = $version + "." + ${env:APPVEYOR_BUILD_NUMBER}
 
           if ($env:APPVEYOR_PULL_REQUEST_NUMBER) {


### PR DESCRIPTION
Updated version of package references:
Set **highest major version** of compatible dependencies for `MailKit`, `MimeKit`, `SmartFormat.NET`, `YAXLib`