### PR TITLE
Removed obsolete SmartObjects as data source

### DIFF
--- a/Src/MailMergeLib.Tests/Message_Variables.cs
+++ b/Src/MailMergeLib.Tests/Message_Variables.cs
@@ -143,54 +143,6 @@ class Message_Variables
     }
 
     [Test]
-    public void MessagesFromListOfSmartObjects()
-    {
-        var dataList = new List<SmartObjects>();
-        var so1 = new SmartObjects(new[] { new Dictionary<string, string> { { "Email", "test@example.com" } }, new Dictionary<string, string> { { "Continent", "Europe" } } });
-        var so2 = new SmartObjects(new[] { new Dictionary<string, string> { { "Email", "2ndRow@example.com" } }, new Dictionary<string, string> { { "Continent", "Asia" } } });
-        var so3 = new SmartObjects(new[] { new Dictionary<string, string> { { "Email", "3ndRow@example.com" } }, new Dictionary<string, string> { { "Continent", "America" } } });
-
-        dataList.AddRange(new[] { so1, so2, so3 });
-
-        const string text = "Lorem ipsum dolor. Email={Email}, Continent={Continent}.";
-
-        using var mmm = new MailMergeMessage("Subject for {Continent}", text);
-        mmm.MailMergeAddresses.Add(new MailMergeAddress(MailAddressType.From, "from@example.com"));
-        mmm.MailMergeAddresses.Add(new MailMergeAddress(MailAddressType.To, "{Email}"));
-
-        var i = 0;
-        foreach (var mimeMessage in mmm.GetMimeMessages<SmartObjects>(dataList))
-        {
-            Assert.IsTrue(mimeMessage.To.ToString().Contains(((Dictionary<string, string>)dataList[i][0])["Email"]));
-            Assert.IsTrue(mimeMessage.TextBody.Contains(text.Replace("{Email}", ((Dictionary<string, string>)dataList[i][0])["Email"]).Replace("{Continent}", ((Dictionary<string, string>)dataList[i][1])["Continent"])));
-            MailMergeMessage.DisposeFileStreams(mimeMessage);
-            i++;
-        }
-    }
-
-    [Test]
-    public void SingleMessageFromSmartObjects()
-    {
-        var anonymous = new { Email = "test@example.com" };
-        var text = "Lorem ipsum dolor. Email={Email}, Continent={Continent}.";
-        var so = new SmartObjects(new object[]
-        {
-            anonymous,
-            new Dictionary<string, string> {{"Continent", "Europe"}}
-        });
-
-        using var mmm = new MailMergeMessage("Subject for {Continent}", text);
-        mmm.MailMergeAddresses.Add(new MailMergeAddress(MailAddressType.From, "from@example.com"));
-        mmm.MailMergeAddresses.Add(new MailMergeAddress(MailAddressType.To, "{Email}"));
-
-        var mimeMessage = mmm.GetMimeMessage(so);
-
-        Assert.IsTrue(mimeMessage.To.ToString().Contains(anonymous.Email));
-        Assert.IsTrue(mimeMessage.TextBody.Contains(text.Replace("{Email}", anonymous.Email).Replace("{Continent}", ((Dictionary<string, string>)so[1])["Continent"])));
-        MailMergeMessage.DisposeFileStreams(mimeMessage);
-    }
-
-    [Test]
     public void MessagesFromListOfValueTuples()
     {
         var dataList = new List<ValueTuple<Dictionary<string, string>, Dictionary<string, string>>>();

--- a/Src/MailMergeLib/MailSmartFormatter.cs
+++ b/Src/MailMergeLib/MailSmartFormatter.cs
@@ -26,7 +26,6 @@ public class MailSmartFormatter : SmartFormatter
             (ISource)listFormatter, // ListFormatter MUST be first
             new DictionarySource(this),
             new ValueTupleSource(this),
-            new SmartObjectsSource(this),
             new JsonSource(this),
             //new XmlSource(this),
             new ReflectionSource(this),


### PR DESCRIPTION
`SmartObjectsSource` has already been replaced by `ValueTupleSource` in a previous version of `SmartFormat`.