### PR TITLE
Update MimeKit package because of a security issue

### DIFF
--- a/Src/MailMergeLib.Tests/Crypto.cs
+++ b/Src/MailMergeLib.Tests/Crypto.cs
@@ -12,7 +12,7 @@ public class Crypto
         var test = new byte[8] { 1, 2, 3, 4, 5, 6, 7, 8 };
         MailMergeLib.Crypto.IV = test;
 
-        Assert.AreEqual(test, MailMergeLib.Crypto.IV);
+        Assert.That(MailMergeLib.Crypto.IV, Is.EqualTo(test));
         MailMergeLib.Crypto.IV = oldValue;
     }
 
@@ -23,7 +23,7 @@ public class Crypto
         var key = "some-random-key-for-testing";
         MailMergeLib.Crypto.CryptoKey = key;
 
-        Assert.AreEqual(key, MailMergeLib.Crypto.CryptoKey);
+        Assert.That(MailMergeLib.Crypto.CryptoKey, Is.EqualTo(key));
         MailMergeLib.Crypto.CryptoKey = oldValue;
     }
 
@@ -34,7 +34,7 @@ public class Crypto
         var encoding = System.Text.Encoding.BigEndianUnicode;
         MailMergeLib.Crypto.Encoding = encoding;
 
-        Assert.AreEqual(encoding, MailMergeLib.Crypto.Encoding);
+        Assert.That(MailMergeLib.Crypto.Encoding, Is.EqualTo(encoding));
         MailMergeLib.Crypto.Encoding = oldValue;
     }
 
@@ -45,6 +45,6 @@ public class Crypto
         const string someValue = "some-random-value-for-testing";
         var encrypted = MailMergeLib.Crypto.Encrypt(someValue);
 
-        Assert.AreEqual(someValue, MailMergeLib.Crypto.Decrypt(encrypted));
+        Assert.That(MailMergeLib.Crypto.Decrypt(encrypted), Is.EqualTo(someValue));
     }
 }

--- a/Src/MailMergeLib.Tests/EmailValidatorTest.cs
+++ b/Src/MailMergeLib.Tests/EmailValidatorTest.cs
@@ -148,24 +148,21 @@ public class EmailValidatorTest
     public void TestValidAddresses()
     {
         for (var i = 0; i < ValidAddresses.Length; i++)
-            Assert.IsTrue(EmailValidator.Validate(ValidAddresses[i], true), "Valid Address #{0}: {1}", i,
-                ValidAddresses[i]);
+            Assert.That(EmailValidator.Validate(ValidAddresses[i], true), Is.True, $"Valid Address #{i}: {ValidAddresses[i]}");
     }
 
     [Test]
     public void TestInvalidAddresses()
     {
         for (var i = 0; i < InvalidAddresses.Length; i++)
-            Assert.IsFalse(EmailValidator.Validate(InvalidAddresses[i], true), "Invalid Address #{0}: {1}", i,
-                InvalidAddresses[i]);
+            Assert.That(EmailValidator.Validate(InvalidAddresses[i], true), Is.False, $"Invalid Address #{i}: {InvalidAddresses[i]}");
     }
 
     [Test]
     public void TestValidInternationalAddresses()
     {
         for (var i = 0; i < ValidInternationalAddresses.Length; i++)
-            Assert.IsTrue(EmailValidator.Validate(ValidInternationalAddresses[i], true, true),
-                "Valid International Address #{0}", i);
+            Assert.That(EmailValidator.Validate(ValidInternationalAddresses[i], true, true), Is.True, $"Valid International Address #{i}");
     }
 
     [Test]

--- a/Src/MailMergeLib.Tests/FileMessageInfo.cs
+++ b/Src/MailMergeLib.Tests/FileMessageInfo.cs
@@ -13,11 +13,15 @@ public class FileMessageInfo
         var info = new MailMergeLib.MessageStore.FileMessageInfo { Id = 1, Category = "Some cat.", Comments = "Somme comments", Description = "No description", Data = "Some data hint", MessageEncoding = Encoding.UTF8, MessageFile = new FileInfo("dummy.xml")};
         var otherInfo = new MailMergeLib.MessageStore.FileMessageInfo { Id = 1, Category = "Some cat.", Comments = "Somme comments", Description = "No description", Data = "Some data hint", MessageEncoding = Encoding.UTF8, MessageFile = new FileInfo("dummy.xml") };
 
-        Assert.AreEqual(info, otherInfo);
-        Assert.IsFalse(info.Equals(null));
-        Assert.IsTrue(info.Equals(info));
-        Assert.IsFalse(info.Equals(new object()));
-        Assert.AreEqual(info.GetHashCode(), otherInfo.GetHashCode());
+        Assert.Multiple(() =>
+        {
+            Assert.That(otherInfo, Is.EqualTo(info));
+            Assert.That(info.Equals(null), Is.False);
+            Assert.That(info.Equals(info), Is.True);
+            Assert.That(info.Equals(new object()), Is.False);
+        });
+
+        Assert.That(otherInfo.GetHashCode(), Is.EqualTo(info.GetHashCode()));
     }
 
     [Test]
@@ -26,10 +30,13 @@ public class FileMessageInfo
         var info = new MailMergeLib.MessageStore.FileMessageInfo { Id = 1, Category = null, Comments = null, Description = "No description", Data = "Some data hint", MessageEncoding = null!, MessageFile = null! };
         var otherInfo = new MailMergeLib.MessageStore.FileMessageInfo { Id = 1, Category = null, Comments = null, Description = "No description", Data = "Some data hint", MessageEncoding = null!, MessageFile = null! };
 
-        Assert.AreEqual(info, otherInfo);
-        Assert.IsFalse(info.Equals(null));
-        Assert.IsTrue(info.Equals(info));
-        Assert.IsFalse(info.Equals(new object()));
-        Assert.AreEqual(info.GetHashCode(), otherInfo.GetHashCode());
+        Assert.Multiple(() =>
+        {
+            Assert.That(otherInfo, Is.EqualTo(info));
+            Assert.That(info.Equals(null), Is.False);
+            Assert.That(info.Equals(info), Is.True);
+            Assert.That(info.Equals(new object()), Is.False);
+        });
+        Assert.That(otherInfo.GetHashCode(), Is.EqualTo(info.GetHashCode()));
     }
 }

--- a/Src/MailMergeLib.Tests/FileMessageStore_Serialization.cs
+++ b/Src/MailMergeLib.Tests/FileMessageStore_Serialization.cs
@@ -14,21 +14,21 @@ public class FileMessageStore_Serialization
     public void SerializeDeserialize()
     {
         var fms = new FileMessageStore(new[] { TestFileFolders.FilesAbsPath }, new[] { "Msg*.xml" }, Encoding.UTF8);
-        Assert.AreEqual(fms, FileMessageStore.Deserialize(fms.Serialize()));
+        Assert.That(FileMessageStore.Deserialize(fms.Serialize()), Is.EqualTo(fms));
     }
 
     [Test]
     public void GetMessageInfosFromFiles()
     {
-        var fms = new FileMessageStore(new[] { TestFileFolders.FilesAbsPath }, new[] {"Msg*.xml"}, Encoding.UTF8);
+        var fms = new FileMessageStore(new[] { TestFileFolders.FilesAbsPath }, new[] { "Msg*.xml" }, Encoding.UTF8);
         var messageInfos = fms.ScanForMessages().ToList();
 
-        Assert.AreEqual(2, messageInfos.Count);
+        Assert.That(messageInfos, Has.Count.EqualTo(2));
 
         foreach (var info in messageInfos)
         {
             // messageInfos come from fast xml scan in MessageInfoBase, Info of the Messsage comes from YAXLib deserialization
-            Assert.AreEqual(info, info.LoadMessage()!.Info);
+            Assert.That(info.Data, Is.EqualTo(info.LoadMessage()!.Info.Data));
         }
     }
 
@@ -37,7 +37,7 @@ public class FileMessageStore_Serialization
     {
         var fms = new FileMessageStore(new[] { TestFileFolders.FilesAbsPath }, new[] { Guid.NewGuid().ToString("N")}, Encoding.UTF8);
         var messageInfos = fms.ScanForMessages().ToList();
-        Assert.AreEqual(0, messageInfos.Count);
+        Assert.That(messageInfos.Count, Is.EqualTo(0));
 
         fms.SearchFolders = new[] { TestFileFolders.FilesAbsPath + Guid.NewGuid().ToString("N")};
         Assert.Throws<DirectoryNotFoundException>(() => messageInfos = fms.ScanForMessages().ToList());
@@ -49,7 +49,7 @@ public class FileMessageStore_Serialization
         var fms = new FileMessageStore(new[] { TestFileFolders.FilesAbsPath }, new[] { Guid.NewGuid().ToString("N") }, Encoding.UTF8);
         var tempFilename = Path.GetTempFileName();
         fms.Serialize(tempFilename, Encoding.UTF8);
-        Assert.True(fms.Equals(FileMessageStore.Deserialize(tempFilename, Encoding.UTF8)));
+        Assert.That(fms.Equals(FileMessageStore.Deserialize(tempFilename, Encoding.UTF8)), Is.True);
         File.Delete(tempFilename);
     }
 
@@ -61,9 +61,12 @@ public class FileMessageStore_Serialization
         fms.Serialize(stream, Encoding.UTF8);
         stream.Position = 0;
         var restoredFms = FileMessageStore.Deserialize(stream, Encoding.UTF8)!;
-        Assert.True(fms.Equals(restoredFms));
+        Assert.Multiple(() =>
+        {
+            Assert.That(fms.Equals(restoredFms), Is.True);
 
-        Assert.AreEqual(fms.GetHashCode(), restoredFms.GetHashCode());
-        Assert.False(fms.Equals(new object()));
+            Assert.That(restoredFms.GetHashCode(), Is.EqualTo(fms.GetHashCode()));
+        });
+        Assert.That(fms.Equals(new object()), Is.False);
     }
 }

--- a/Src/MailMergeLib.Tests/HtmlBodyBuilderTest.cs
+++ b/Src/MailMergeLib.Tests/HtmlBodyBuilderTest.cs
@@ -22,12 +22,12 @@ public class HtmlBodyBuilderTest
     [TestCase("/tmp", IncludePlatform = nameof(OpSys.Linux) + "," + nameof(OpSys.MacOsX))]
     [TestCase("C:\\Temp", ExcludePlatform = nameof(OpSys.Linux) + "," + nameof(OpSys.MacOsX))]
     [TestCase("\\\\some\\unc\\path", ExcludePlatform = nameof(OpSys.Linux) + "," + nameof(OpSys.MacOsX))]
-    public void SetHtmlBuilderDocBaseUri_NoException(string baseUri)
+    public void SetHtmlBuilderDocBaseUri_NoException(string? baseUri)
     {
         var mmm = new MailMergeMessage("subject", "plain text",
             "<html><head><base href=\"\" /></head><body></body></html>");
         var hbb = new HtmlBodyBuilder(mmm, null);
-        Assert.DoesNotThrow(() => hbb.DocBaseUri = baseUri);
+        Assert.DoesNotThrow(() => hbb.DocBaseUri = baseUri!);
     }
 
     [Test]
@@ -37,8 +37,11 @@ public class HtmlBodyBuilderTest
             "<html><head><script>var x='x';</script><script>var y='y';</script></head><body>some body</body></html>");
         var hbb = new HtmlBodyBuilder(mmm, null);
         var html = hbb.GetBodyPart();
-        Assert.IsTrue(html.ToString().Contains("some body"));
-        Assert.IsTrue(!html.ToString().Contains("script"));
+        Assert.Multiple(() =>
+        {
+            Assert.That(html.ToString().Contains("some body"), Is.True);
+            Assert.That(!html.ToString().Contains("script"), Is.True);
+        });
     }
 
     [Test]
@@ -49,7 +52,7 @@ public class HtmlBodyBuilderTest
             "<html><head><title>abc</title></head><body></body></html>");
         var hbb = new HtmlBodyBuilder(mmm, null);
         var html = hbb.GetBodyPart();
-        Assert.IsTrue(html.ToString().Contains(subjectToSet));
+        Assert.That(html.ToString().Contains(subjectToSet), Is.True);
     }
 
     [Test]
@@ -59,7 +62,7 @@ public class HtmlBodyBuilderTest
         var mmm = new MailMergeMessage(subjectToSet, "plain text", "<html><head></head><body></body></html>");
         var hbb = new HtmlBodyBuilder(mmm, null);
         var html = hbb.GetBodyPart();
-        Assert.IsTrue(!html.ToString().Contains(subjectToSet));
+        Assert.That(!html.ToString().Contains(subjectToSet), Is.True);
     }
 
     [Test]

--- a/Src/MailMergeLib.Tests/MailMergeLib.Tests.csproj
+++ b/Src/MailMergeLib.Tests/MailMergeLib.Tests.csproj
@@ -3,7 +3,7 @@
     <PropertyGroup>
         <Description>Test project for MailMergeLib</Description>
         <AssemblyTitle>MailMergeLib.UnitTest</AssemblyTitle>
-        <TargetFrameworks>netcoreapp3.1;net462;net6.0</TargetFrameworks>
+        <TargetFrameworks>net462;net6.0</TargetFrameworks>
         <GenerateDocumentationFile>false</GenerateDocumentationFile>
         <AssemblyName>MailMergeLib.Tests</AssemblyName>
         <AssemblyOriginatorKeyFile>../MailMergeLib/MailMergeLib.snk</AssemblyOriginatorKeyFile>
@@ -34,10 +34,14 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageReference Include="Microsoft.DotNet.PlatformAbstractions" Version="3.1.6" />
-    <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="7.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.3" />
-    <PackageReference Include="netDumbster" Version="3.0.1" />
-    <PackageReference Include="NUnit" Version="3.13.3" />
+    <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="8.0.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
+    <PackageReference Include="netDumbster" Version="3.1.0" />
+    <PackageReference Include="NUnit" Version="4.1.0" />
+    <PackageReference Include="NUnit.Analyzers" Version="4.2.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
     <PackageReference Include="System.ValueTuple" Version="4.5.0" />
   </ItemGroup>

--- a/Src/MailMergeLib.Tests/MessageInfo.cs
+++ b/Src/MailMergeLib.Tests/MessageInfo.cs
@@ -23,10 +23,16 @@ public class MessageInfo
 
         // MessageInfo
         var deserializedInfo = MailMergeLib.MessageStore.MessageInfoBase.Read(xml);
-        Assert.AreEqual(info, deserializedInfo);
-        Assert.IsTrue(info.Equals(info));
-        Assert.IsFalse(info.Equals(new object()));
-        Assert.AreEqual(info.GetHashCode(), deserializedInfo.GetHashCode());
+        Assert.Multiple(() =>
+        {
+            Assert.That(deserializedInfo, Is.EqualTo(info));
+            Assert.That(info.Equals(info), Is.True);
+        });
+        Assert.Multiple(() =>
+        {
+            Assert.That(info.Equals(new object()), Is.False);
+            Assert.That(deserializedInfo.GetHashCode(), Is.EqualTo(info.GetHashCode()));
+        });
     }
 
     [Test]
@@ -42,10 +48,16 @@ public class MessageInfo
 
         // MessageInfo
         var deserializedInfo = MailMergeLib.MessageStore.MessageInfoBase.Read(xml);
-        Assert.AreEqual(info, deserializedInfo);
-        Assert.IsTrue(info.Equals(info));
-        Assert.IsFalse(info.Equals(new object()));
-        Assert.AreEqual(info.GetHashCode(), deserializedInfo.GetHashCode());
+        Assert.Multiple(() =>
+        {
+            Assert.That(deserializedInfo, Is.EqualTo(info));
+            Assert.That(info.Equals(info), Is.True);
+        });
+        Assert.Multiple(() =>
+        {
+            Assert.That(info.Equals(new object()), Is.False);
+            Assert.That(deserializedInfo.GetHashCode(), Is.EqualTo(info.GetHashCode()));
+        });
     }
 
     [Test]

--- a/Src/MailMergeLib.Tests/Message_Config.cs
+++ b/Src/MailMergeLib.Tests/Message_Config.cs
@@ -19,10 +19,10 @@ public class Message_Config
     [TestCase("C:\\some\\path\\to\\folder", "C:\\some\\path\\to\\folder", ExcludePlatform =
         nameof(OpSys.Linux) + "," + nameof(OpSys.MacOsX))]
     [TestCase("/some/path/to/folder", "/some/path/to/folder", IncludePlatform = nameof(OpSys.Linux) + "," + nameof(OpSys.MacOsX))]
-    public void SetFileBaseDirectory(string path, string expected)
+    public void SetFileBaseDirectory(string? path, string expected)
     {
-        _msgConfig.FileBaseDirectory = path;
-        Assert.AreEqual(expected, _msgConfig.FileBaseDirectory);
+        _msgConfig.FileBaseDirectory = path ?? string.Empty;
+        Assert.That(_msgConfig.FileBaseDirectory, Is.EqualTo(expected));
     }
 
     [TestCase(" \t", false)]
@@ -35,12 +35,12 @@ public class Message_Config
     [TestCase("noFullPath", true)]
     [TestCase("..\\..\\relativePath", true, ExcludePlatform = nameof(OpSys.Linux) + "," + nameof(OpSys.MacOsX))]
     [TestCase("../../relativePath", true, IncludePlatform = nameof(OpSys.Linux) + "," + nameof(OpSys.MacOsX))]
-    public void FileBaseDirectory_must_be_full_path_when_processing_the_message(string path, bool shouldThrow)
+    public void FileBaseDirectory_must_be_full_path_when_processing_the_message(string? path, bool shouldThrow)
     {
         var mmm = new MailMergeMessage("subject", "plain text", "<html><body></body></html>");
         mmm.MailMergeAddresses.Add(new MailMergeAddress(MailAddressType.To, "to@example.org"));
         mmm.MailMergeAddresses.Add(new MailMergeAddress(MailAddressType.From, "from@example.org"));
-        mmm.Config.FileBaseDirectory = path;
+        mmm.Config.FileBaseDirectory = path ?? string.Empty;
 
         if (shouldThrow)
         {
@@ -50,8 +50,11 @@ public class Message_Config
             }
             catch (Exception e)
             {
-                Assert.IsTrue(e is MailMergeMessage.MailMergeMessageException);
-                Assert.IsTrue(e.InnerException != null);
+                Assert.Multiple(() =>
+                {
+                    Assert.That(e is MailMergeMessage.MailMergeMessageException, Is.True);
+                    Assert.That(e.InnerException != null, Is.True);
+                });
             }
         }
         else
@@ -83,7 +86,7 @@ public class Message_Config
         else
         {
             hbb = new HtmlBodyBuilder(mmm, null);
-            Assert.AreEqual(expected, hbb.DocBaseUri);
+            Assert.That(hbb.DocBaseUri, Is.EqualTo(expected));
         }
     }
 
@@ -95,7 +98,7 @@ public class Message_Config
         mmm.Config.FileBaseDirectory = Path.GetTempPath();
 
         var hbb = new HtmlBodyBuilder(mmm, null);
-        Assert.AreEqual( new Uri(mmm.Config.FileBaseDirectory), hbb.DocBaseUri);
+        Assert.That(hbb.DocBaseUri, Is.EqualTo(new Uri(mmm.Config.FileBaseDirectory).ToString()));
     }
 
     [Test]
@@ -108,7 +111,7 @@ public class Message_Config
 
         var hbb = new HtmlBodyBuilder(mmm, null);
         hbb.GetBodyPart();
-        Assert.AreEqual(baseTagHref, hbb.DocBaseUri);
+        Assert.That(hbb.DocBaseUri, Is.EqualTo(baseTagHref));
     }
 
     [Test]
@@ -117,9 +120,7 @@ public class Message_Config
         var mc1 = new MessageConfig();
         var mc2 = new MessageConfig();
 
-        Assert.AreEqual(mc1.GetHashCode(), mc2.GetHashCode());
-        Assert.AreEqual(mc1.GetHashCode(), mc1.GetHashCode());
-        Assert.AreEqual(mc2.GetHashCode(), mc2.GetHashCode());
+        Assert.That(mc2.GetHashCode(), Is.EqualTo(mc1.GetHashCode()));
     }
 
     [Test]

--- a/Src/MailMergeLib.Tests/Message_Equality.cs
+++ b/Src/MailMergeLib.Tests/Message_Equality.cs
@@ -18,8 +18,8 @@ public class Message_Equality
     [Test]
     public void MailMergeAddressEquality()
     {
-        Assert.True(_addr1a.Equals(_addr1b));
-        Assert.False(_addr1a.Equals(_addr3));
+        Assert.That(_addr1a.Equals(_addr1b), Is.True);
+        Assert.That(_addr1a.Equals(_addr3), Is.False);
     }
 
     [Test]
@@ -29,12 +29,15 @@ public class Message_Equality
         var addrColl2 = new MailMergeAddressCollection {_addr2b, _addr1b};
         var addrColl1_Ref = addrColl1;
 
-        Assert.True(addrColl1.Equals(addrColl2));
-        Assert.True(addrColl1.Equals(addrColl1_Ref));
-        Assert.False(addrColl1.Equals(_addr1a));
+        Assert.Multiple(() =>
+        {
+            Assert.That(addrColl1.Equals(addrColl2), Is.True);
+            Assert.That(addrColl1.Equals(addrColl1_Ref), Is.True);
+        });
+        Assert.That(addrColl1.Equals(_addr1a), Is.False);
 
         addrColl2.Add(_addr3);
-        Assert.False(addrColl1.Equals(addrColl2));
+        Assert.That(addrColl1.Equals(addrColl2), Is.False);
     }
 
     [TestCase(MailAddressType.To)]
@@ -53,16 +56,16 @@ public class Message_Equality
         switch (addrType)
         {
             case MailAddressType.To:
-                Assert.AreEqual(_addr1a, addrColl.Get(addrType).FirstOrDefault());
+                Assert.That(addrColl.Get(addrType).FirstOrDefault(), Is.EqualTo(_addr1a));
                 break;
             case MailAddressType.Bcc:
-                Assert.AreEqual(_addr2a, addrColl.Get(addrType).FirstOrDefault());
+                Assert.That(addrColl.Get(addrType).FirstOrDefault(), Is.EqualTo(_addr2a));
                 break;
             case MailAddressType.From:
-                Assert.AreEqual(_addr3, addrColl.Get(addrType).FirstOrDefault());
+                Assert.That(addrColl.Get(addrType).FirstOrDefault(), Is.EqualTo(_addr3));
                 break;
             default:
-                Assert.AreEqual(null, addrColl.Get(addrType).FirstOrDefault());
+                Assert.That(addrColl.Get(addrType).FirstOrDefault(), Is.EqualTo(null));
                 break;
         }
     }
@@ -73,8 +76,8 @@ public class Message_Equality
         var mmm = new MailMergeMessage();
         mmm.MailMergeAddresses.Add(_addr1a);
         mmm.MailMergeAddresses.Add(_addr2a);
-            
-        Assert.AreEqual($"\"{_addr1a.DisplayName}\" <{_addr1a.Address}>", mmm.MailMergeAddresses.ToString(MailAddressType.To, null));
+
+        Assert.That(mmm.MailMergeAddresses.ToString(MailAddressType.To, null), Is.EqualTo($"\"{_addr1a.DisplayName}\" <{_addr1a.Address}>"));
     }
 
     [Test]
@@ -86,7 +89,7 @@ public class Message_Equality
         mmm.MailMergeAddresses.Add(_addr3);
         var addrColl = new MailMergeAddressCollection { _addr1a, _addr2a, _addr3 };
 
-        Assert.AreEqual(mmm.MailMergeAddresses.GetHashCode(), addrColl.GetHashCode());
+        Assert.That(addrColl.GetHashCode(), Is.EqualTo(mmm.MailMergeAddresses.GetHashCode()));
     }
 
     [Test]
@@ -96,8 +99,8 @@ public class Message_Equality
         var fa2 = new FileAttachment("filename", "display name", "txt/html");
         var fa3 = new FileAttachment("filename 3", "display name", "txt/html");
 
-        Assert.True(fa1.Equals(fa2));
-        Assert.False(fa1.Equals(fa3));
+        Assert.That(fa1.Equals(fa2), Is.True);
+        Assert.That(fa1.Equals(fa3), Is.False);
     }
 
     [Test]
@@ -107,8 +110,8 @@ public class Message_Equality
         var sa2 = new StringAttachment("Content", "display name", "txt/html");
         var sa3 = new StringAttachment("Content", "display name", "txt/plain");
 
-        Assert.True(sa1.Equals(sa2));
-        Assert.False(sa1.Equals(sa3));
+        Assert.That(sa1.Equals(sa2), Is.True);
+        Assert.That(sa1.Equals(sa3), Is.False);
     }
 
     [Test]
@@ -118,17 +121,26 @@ public class Message_Equality
         var mmm2 = MailMergeLib.MailMergeMessage.Deserialize(mmm1.Serialize())!;
         var mmm3 = MessageFactory.GetMessageWithAllPropertiesSet()!;
 
-        Assert.IsTrue(mmm1.Equals(mmm2));
-        Assert.IsTrue(mmm1.Equals(mmm3));
+        Assert.That(mmm1.Equals(mmm2), Is.True);
+        Assert.That(mmm1.Equals(mmm2), Is.True);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(mmm1, Is.EqualTo(mmm2));
+            Assert.That(mmm1, Is.EqualTo(mmm3));
+        });
 
         mmm2.HtmlText += "?";
-        Assert.IsFalse(mmm1.Equals(mmm2));
+        Assert.That(mmm1.Equals(mmm2), Is.False);
 
         mmm3.MailMergeAddresses.RemoveAt(0);
-        Assert.IsFalse(mmm1.Equals(mmm3));
+        Assert.Multiple(() =>
+        {
+            Assert.That(mmm1.Equals(mmm3), Is.False);
 
-        Assert.IsTrue(mmm1.Equals(mmm1));
-        Assert.IsFalse(mmm1.Equals(new object()));
+            Assert.That(mmm1.Equals(mmm1), Is.True);
+            Assert.That(mmm1.Equals(new object()), Is.False);
+        });
     }
 
     [Test]

--- a/Src/MailMergeLib.Tests/Message_Html.cs
+++ b/Src/MailMergeLib.Tests/Message_Html.cs
@@ -31,10 +31,10 @@ public class Message_Html
             var mimeMessage = mmm.GetMimeMessage(null);
 
             var size = MailMergeLib.Tools.CalcMessageSize(mimeMessage);
-            Assert.IsTrue(size > 0);
+            Assert.That(size > 0, Is.True);
         }
 
-        Assert.IsTrue(MailMergeLib.Tools.CalcMessageSize(null) == 0);
+        Assert.That(MailMergeLib.Tools.CalcMessageSize(null) == 0, Is.True);
     }
 
     [Test]
@@ -50,8 +50,11 @@ public class Message_Html
         }
         catch (Exception e)
         {
-            Assert.IsTrue(e is MailMergeMessage.MailMergeMessageException);
-            Assert.IsTrue(e.InnerException is MailMergeMessage.EmptyContentException);
+            Assert.Multiple(() =>
+            {
+                Assert.That(e is MailMergeMessage.MailMergeMessageException, Is.True);
+                Assert.That(e.InnerException is MailMergeMessage.EmptyContentException, Is.True);
+            });
         }
     }
 
@@ -60,9 +63,12 @@ public class Message_Html
     {
         using var basicMmm = MessageFactory.GetHtmlMailWithInlineAndOtherAttachments();
         using var mmm = new MailMergeMessage("The subject", "plain text", basicMmm.FileAttachments);
-        Assert.AreEqual("The subject", mmm.Subject);
-        Assert.AreEqual("plain text", mmm.PlainText);
-        Assert.AreEqual(basicMmm.FileAttachments.Count, mmm.FileAttachments.Count);
+        Assert.Multiple(() =>
+        {
+            Assert.That(mmm.Subject, Is.EqualTo("The subject"));
+            Assert.That(mmm.PlainText, Is.EqualTo("plain text"));
+            Assert.That(mmm.FileAttachments, Has.Count.EqualTo(basicMmm.FileAttachments.Count));
+        });
     }
 
     [Test]
@@ -70,10 +76,13 @@ public class Message_Html
     {
         using var basicMmm = MessageFactory.GetHtmlMailWithInlineAndOtherAttachments();
         using var mmm = new MailMergeMessage("The subject", "plain text", "<html>html</html>", basicMmm.FileAttachments);
-        Assert.AreEqual("The subject", mmm.Subject);
-        Assert.AreEqual("plain text", mmm.PlainText);
-        Assert.AreEqual("<html>html</html>", mmm.HtmlText);
-        Assert.AreEqual(basicMmm.FileAttachments.Count, mmm.FileAttachments.Count);
+        Assert.Multiple(() =>
+        {
+            Assert.That(mmm.Subject, Is.EqualTo("The subject"));
+            Assert.That(mmm.PlainText, Is.EqualTo("plain text"));
+            Assert.That(mmm.HtmlText, Is.EqualTo("<html>html</html>"));
+            Assert.That(mmm.FileAttachments, Has.Count.EqualTo(basicMmm.FileAttachments.Count));
+        });
     }
 
     [Test]
@@ -94,16 +103,19 @@ public class Message_Html
         msg.WriteTo(msgFilename);
         Console.WriteLine($"Test mime message saved as {msgFilename}");
 
-        Assert.IsTrue(((MailboxAddress)msg.From.First()).Address == dataItem.SenderAddr);
-        Assert.IsTrue(((MailboxAddress)msg.To.First()).Address == dataItem.MailboxAddr);
-        Assert.IsTrue(((MailboxAddress)msg.To.First()).Name == dataItem.Name);
-        Assert.IsTrue(msg.Headers[HeaderId.Organization] == mmm.Config.Organization);
-        Assert.IsTrue(msg.Priority == mmm.Config.Priority);
-        Assert.IsTrue(msg.Attachments.FirstOrDefault(a => ((MimePart)a).FileName == "Log file from {Date:yyyy-MM-dd}.log".Replace("{Date:yyyy-MM-dd}", dataItem.Date.ToString("yyyy-MM-dd"))) != null);
-        Assert.IsTrue(msg.Subject == mmm.Subject.Replace("{Date:yyyy-MM-dd}", dataItem.Date.ToString("yyyy-MM-dd")));
-        Assert.IsTrue(msg.HtmlBody.Contains(dataItem.Success ? "succeeded" : "failed"));
-        Assert.IsTrue(msg.TextBody.Contains(dataItem.Success ? "succeeded" : "failed"));
-        Assert.IsTrue(msg.BodyParts.Any(bp => bp.ContentDisposition?.Disposition == ContentDisposition.Inline && bp.ContentType.IsMimeType("image", "jpeg")));
+        Assert.Multiple(() =>
+        {
+            Assert.That(((MailboxAddress) msg.From.First()).Address == dataItem.SenderAddr, Is.True);
+            Assert.That(((MailboxAddress) msg.To.First()).Address == dataItem.MailboxAddr, Is.True);
+            Assert.That(((MailboxAddress) msg.To.First()).Name == dataItem.Name, Is.True);
+            Assert.That(msg.Headers[HeaderId.Organization] == mmm.Config.Organization, Is.True);
+            Assert.That(msg.Priority == mmm.Config.Priority, Is.True);
+            Assert.That(msg.Attachments.FirstOrDefault(a => ((MimePart) a).FileName == "Log file from {Date:yyyy-MM-dd}.log".Replace("{Date:yyyy-MM-dd}", dataItem.Date.ToString("yyyy-MM-dd"))) != null, Is.True);
+            Assert.That(msg.Subject == mmm.Subject.Replace("{Date:yyyy-MM-dd}", dataItem.Date.ToString("yyyy-MM-dd")), Is.True);
+            Assert.That(msg.HtmlBody.Contains(dataItem.Success ? "succeeded" : "failed"), Is.True);
+            Assert.That(msg.TextBody.Contains(dataItem.Success ? "succeeded" : "failed"), Is.True);
+            Assert.That(msg.BodyParts.Any(bp => bp.ContentDisposition?.Disposition == ContentDisposition.Inline && bp.ContentType.IsMimeType("image", "jpeg")), Is.True);
+        });
 
         MailMergeMessage.DisposeFileStreams(msg);
     }
@@ -122,12 +134,12 @@ public class Message_Html
             mmm.StreamAttachments.Add(new StreamAttachment(stream, streamAttFilename, "text/plain"));
         }
 
-        Assert.IsTrue(mmm.StreamAttachments.Count == 1);
+        Assert.That(mmm.StreamAttachments.Count == 1, Is.True);
         mmm.StreamAttachments.Clear();
-        Assert.IsTrue(mmm.StreamAttachments.Count == 0);
+        Assert.That(mmm.StreamAttachments.Count == 0, Is.True);
 
         mmm.StreamAttachments = streamAttachments;
-        Assert.IsTrue(mmm.StreamAttachments.Count == 2);
+        Assert.That(mmm.StreamAttachments.Count == 2, Is.True);
     }
 
 
@@ -157,8 +169,11 @@ public class Message_Html
 
         var msg = mmm.GetMimeMessage(dataItem);
         var att = msg.Attachments.FirstOrDefault() as MimePart;
-        Assert.IsTrue(att?.FileName == streamAttFilename && att.IsAttachment);
-        Assert.IsTrue(msg.ToString().Contains(text));
+        Assert.Multiple(() =>
+        {
+            Assert.That(att?.FileName == streamAttFilename && att.IsAttachment, Is.True);
+            Assert.That(msg.ToString().Contains(text), Is.True);
+        });
 
         MailMergeMessage.DisposeFileStreams(msg);
     }
@@ -182,8 +197,11 @@ public class Message_Html
         msg.WriteTo(msgFilename);
         Console.WriteLine($"Test mime message saved as {msgFilename}");
 
-        Assert.IsTrue(new HtmlParser().ParseDocument((string)msg.HtmlBody).All.Count(m => m is IHtmlImageElement) == 3);
-        Assert.IsTrue(msg.BodyParts.Count(bp => bp.ContentDisposition?.Disposition == ContentDisposition.Inline && bp.ContentType.IsMimeType("image", "jpeg")) == 1);
+        Assert.Multiple(() =>
+        {
+            Assert.That(new HtmlParser().ParseDocument((string) msg.HtmlBody).All.Count(m => m is IHtmlImageElement) == 3, Is.True);
+            Assert.That(msg.BodyParts.Count(bp => bp.ContentDisposition?.Disposition == ContentDisposition.Inline && bp.ContentType.IsMimeType("image", "jpeg")) == 1, Is.True);
+        });
 
         MailMergeMessage.DisposeFileStreams(msg);
     }
@@ -202,7 +220,7 @@ public class Message_Html
 
         using var mmm = MessageFactory.GetHtmlMsgWithManualLinkedResources();
         var msg = mmm.GetMimeMessage(dataItem);
-        Assert.IsTrue(msg.BodyParts.Any(bp => bp.ContentDisposition?.Disposition == ContentDisposition.Inline && bp.ContentType.IsMimeType("image", "jpeg") && bp.ContentId == MessageFactory.MyContentId));
+        Assert.That(msg.BodyParts.Any(bp => bp.ContentDisposition?.Disposition == ContentDisposition.Inline && bp.ContentType.IsMimeType("image", "jpeg") && bp.ContentId == MessageFactory.MyContentId), Is.True);
         MailMergeMessage.DisposeFileStreams(msg);
     }
 
@@ -253,7 +271,7 @@ public class Message_Html
         mmm.MailMergeAddresses.Add(new MailMergeAddress(MailAddressType.To, "to@sample.com"));
 
         var msg = mmm.GetMimeMessage();
-        Assert.IsTrue(msg.ToString().Contains(embeddedImage));
+        Assert.That(msg.ToString().Contains(embeddedImage), Is.True);
         MailMergeMessage.DisposeFileStreams(msg);
     }
 
@@ -270,7 +288,7 @@ public class Message_Html
         mmm.MailMergeAddresses.Add(new MailMergeAddress(MailAddressType.To, "to@sample.com"));
 
         var msg = mmm.GetMimeMessage();
-        Assert.IsTrue(msg.ToString().Contains(httpImage));
+        Assert.That(msg.ToString().Contains(httpImage), Is.True);
         MailMergeMessage.DisposeFileStreams(msg);
     }
 
@@ -278,12 +296,12 @@ public class Message_Html
     public void ConvertHtmlToPlainText()
     {
         using var mmm = MessageFactory.GetHtmlMessageForHtmlConverter();
-        Assert.IsTrue(string.IsNullOrEmpty(mmm.PlainText));
+        Assert.That(string.IsNullOrEmpty(mmm.PlainText), Is.True);
         mmm.ConvertHtmlToPlainText();
-        Assert.IsTrue(mmm.PlainText.Length > 0);
+        Assert.That(mmm.PlainText.Length > 0, Is.True);
 
         mmm.ConvertHtmlToPlainText(new DummyHtmlConverter());
-        Assert.AreEqual(DummyHtmlConverter.ConstantText, mmm.PlainText);
+        Assert.That(mmm.PlainText, Is.EqualTo(DummyHtmlConverter.ConstantText));
     }
 
     [TestCase("{Name} {SenderAddr}", "John test@specimen.com")]
@@ -302,7 +320,7 @@ public class Message_Html
         mmm.Config.SmartFormatterConfig.FormatErrorAction = ErrorAction.ThrowError;
         mmm.Config.SmartFormatterConfig.ParseErrorAction = ErrorAction.ThrowError;
         var result = mmm.SearchAndReplaceVars(text, dataItem);
-        Assert.AreEqual(expected, result);
+        Assert.That(result, Is.EqualTo(expected));
     }
 
     [TestCase("{Name} {SenderAddr}", "John test@specimen.com")]
@@ -321,6 +339,6 @@ public class Message_Html
         mmm.Config.SmartFormatterConfig.FormatErrorAction = ErrorAction.ThrowError;
         mmm.Config.SmartFormatterConfig.ParseErrorAction = ErrorAction.ThrowError;
         var result = mmm.SearchAndReplaceVarsInFilename(text, dataItem);
-        Assert.AreEqual(expected, result);
+        Assert.That(result, Is.EqualTo(expected));
     }
 }

--- a/Src/MailMergeLib.Tests/Message_Serialization.cs
+++ b/Src/MailMergeLib.Tests/Message_Serialization.cs
@@ -17,8 +17,11 @@ public class Message_Serialization
         var result = mmm.Serialize();
         var back = MailMergeMessage.Deserialize(result)!;
 
-        Assert.True(mmm.Equals(back));
-        Assert.AreEqual(mmm.Serialize(), back.Serialize());
+        Assert.Multiple(() =>
+        {
+            Assert.That(mmm.Equals(back), Is.True);
+            Assert.That(back.Serialize(), Is.EqualTo(mmm.Serialize()));
+        });
     }
 
     [Test]
@@ -29,8 +32,11 @@ public class Message_Serialization
         mmm.Serialize(filename, Encoding.Unicode);
         var back = MailMergeMessage.Deserialize(filename, Encoding.Unicode)!;
 
-        Assert.True(mmm.Equals(back));
-        Assert.AreEqual(mmm.Serialize(), back.Serialize());
+        Assert.Multiple(() =>
+        {
+            Assert.That(mmm.Equals(back), Is.True);
+            Assert.That(back.Serialize(), Is.EqualTo(mmm.Serialize()));
+        });
     }
 
     [Test]
@@ -45,8 +51,11 @@ public class Message_Serialization
         msOut.Close();
         msOut.Dispose();
 
-        Assert.True(mmm.Equals(back));
-        Assert.AreEqual(mmm.Serialize(), back.Serialize());
+        Assert.Multiple(() =>
+        {
+            Assert.That(mmm.Equals(back), Is.True);
+            Assert.That(back.Serialize(), Is.EqualTo(mmm.Serialize()));
+        });
     }
 
     [Test]
@@ -58,11 +67,11 @@ public class Message_Serialization
         mmm.MailMergeAddresses.Add(new MailMergeAddress(MailAddressType.To, "test2@abc.com"));
 
         var mime = mmm.GetMimeMessage(new {Date = DateTime.Now, Success = true, Name = "Joe"});
-        Assert.IsTrue(mime.BodyParts.FirstOrDefault(mbp => mbp.ContentId == "error-image.jpg") != null);
+        Assert.That(mime.BodyParts.FirstOrDefault(mbp => mbp.ContentId == "error-image.jpg") != null, Is.True);
 
         mmm.ClearExternalInlineAttachment();
         mime = mmm.GetMimeMessage(new { Date = DateTime.Now, Success = true, Name = "Joe" });
-        Assert.IsTrue(mime.BodyParts.FirstOrDefault(mbp => mbp.ContentId == "error-image.jpg") == null);
+        Assert.That(mime.BodyParts.FirstOrDefault(mbp => mbp.ContentId == "error-image.jpg") == null, Is.True);
     }
 
     [Test]
@@ -70,7 +79,7 @@ public class Message_Serialization
     {
         // an empty deserialized message and new message must be equal
         var mmm = MailMergeMessage.Deserialize("<MailMergeMessage></MailMergeMessage>")!;
-        Assert.True(new MailMergeMessage().Equals(mmm));
+        Assert.That(new MailMergeMessage().Equals(mmm), Is.True);
     }
 
     [Test]
@@ -98,7 +107,10 @@ public class Message_Serialization
         var back = new MailMergeMessage();
         back.Templates.AddRange(Templates.Templates.Deserialize(result)!);
 
-        Assert.True(templates.Equals(back.Templates));
-        Assert.AreEqual(templates.Serialize(), back.Templates.Serialize());
+        Assert.Multiple(() =>
+        {
+            Assert.That(templates.Equals(back.Templates), Is.True);
+            Assert.That(back.Templates.Serialize(), Is.EqualTo(templates.Serialize()));
+        });
     }
 }

--- a/Src/MailMergeLib.Tests/Message_SmartFormatter.cs
+++ b/Src/MailMergeLib.Tests/Message_SmartFormatter.cs
@@ -47,13 +47,16 @@ public class Message_SmartFormatter
         mmm.Config.SmartFormatterConfig.FormatErrorAction = ErrorAction.OutputErrorInResult;
         mmm.Config.SmartFormatterConfig.ParseErrorAction = ErrorAction.OutputErrorInResult;
 
-        Assert.AreEqual(dataItem.Email, mmm.SmartFormatter.Format("{Email}", dataItem));
-        Assert.AreNotEqual(dataItem.Email, mmm.SmartFormatter.Format("{EmAiL}", dataItem));
+        Assert.Multiple(() =>
+        {
+            Assert.That(mmm.SmartFormatter.Format("{Email}", dataItem), Is.EqualTo(dataItem.Email));
+            Assert.That(mmm.SmartFormatter.Format("{EmAiL}", dataItem), Is.Not.EqualTo(dataItem.Email));
+        });
         // Changing the the SmartFormatterConfig settings creates a new instance of
         // the SmartFormatter inside MailMergeMessage
         mmm.Config.SmartFormatterConfig.CaseSensitivity = CaseSensitivityType.CaseInsensitive;
         var actual = mmm.SmartFormatter.Format("{EmAiL}", dataItem);
-        Assert.AreEqual(dataItem.Email, actual);
+        Assert.That(actual, Is.EqualTo(dataItem.Email));
     }
 
 
@@ -70,7 +73,7 @@ public class Message_SmartFormatter
         var text = "Lorem ipsum dolor. Email={Email}, Continent={GetContinent}, City={GetNewTestClass.City}.";
         var result = smf.Format(culture, text, dataItem);
         var expected = string.Format($"Lorem ipsum dolor. Email={((TestClass)dataItem).Email}, Continent={((TestClass)dataItem).GetContinent()}, City={((TestClass)dataItem).GetNewTestClass().City}.");
-        Assert.AreEqual(expected, result);
+        Assert.That(result, Is.EqualTo(expected));
         Console.WriteLine("Class instances: passed");
 
         // ******** Anonymous type ********
@@ -84,21 +87,21 @@ public class Message_SmartFormatter
         text = "Lorem ipsum dolor. Email={Email}, Continent={Continent}, City={NewTestClass.City}.";
         result = smf.Format(culture, text, dataItem);
         expected = "Lorem ipsum dolor. Email=test@example.com, Continent=Europe, City=New York.";
-        Assert.AreEqual(expected, result);
+        Assert.That(result, Is.EqualTo(expected));
         Console.WriteLine("Anonymous type: passed");
 
         // ******** List ********
         dataItem = new List<string>() { "Lorem", "ipsum", "dolor" };  // this works
         result = smf.Format("{0:list:{}|, |, and }", dataItem);
         expected = "Lorem, ipsum, and dolor";
-        Assert.AreEqual(expected, result);
+        Assert.That(result, Is.EqualTo(expected));
         Console.WriteLine("List: passed");
 
         // ******** Array ********
         dataItem = new[] { "Lorem", "ipsum", "dolor" };
         result = smf.Format("{0:list:{}|, |, and }", dataItem);
         expected = "Lorem, ipsum, and dolor";
-        Assert.AreEqual(expected, result);
+        Assert.That(result, Is.EqualTo(expected));
         Console.WriteLine("Array: passed");
 
         // ******** Dictionary ********
@@ -107,7 +110,7 @@ public class Message_SmartFormatter
         text = "Lorem ipsum dolor. Email={Email}, Continent={Continent}.";
         expected = text.Replace("{Email}", "test@example.com").Replace("{Continent}", "Europe");
         result = smf.Format(culture, text, dataItem);
-        Assert.AreEqual(expected,result);
+        Assert.That(result, Is.EqualTo(expected));
         Console.WriteLine("Dictionary: passed");
 
         // ******** JSON ********
@@ -115,7 +118,7 @@ public class Message_SmartFormatter
         dataItem = JObject.Parse("{ 'Email':'test@example.com', 'Continent':'Europe' }");
         expected = text.Replace("{Email}", "test@example.com").Replace("{Continent}", "Europe");
         result = smf.Format(culture, text, dataItem);
-        Assert.AreEqual(expected, result);
+        Assert.That(result, Is.EqualTo(expected));
         Console.WriteLine("JSON Object: passed");
         // JArray
         dataItem = JObject.Parse(@"
@@ -135,7 +138,7 @@ public class Message_SmartFormatter
 ");
         expected = "Acme Corp, Contoso, and Jumbo";
         result = smf.Format(culture, "{Manufacturers:list:{Name}|, |, and }", dataItem);
-        Assert.AreEqual(expected, result);
+        Assert.That(result, Is.EqualTo(expected));
         Console.WriteLine("JSON Array: passed");
 
         // ******** ExpandoObject ********
@@ -147,7 +150,7 @@ public class Message_SmartFormatter
         text = "Lorem ipsum dolor. Email={Email}, Continent={Continent}.";
         result = smf.Format(culture, text, dataItem);
         expected = text.Replace("{Email}", "test@example.com").Replace("{Continent}", "Europe");
-        Assert.AreEqual(expected, result);
+        Assert.That(result, Is.EqualTo(expected));
         Console.WriteLine("ExpandoObject: passed");
 
         // ******** DataRow ********
@@ -174,7 +177,7 @@ public class Message_SmartFormatter
             
         expected = text.Replace("{Email}", "test@example.com").Replace("{Continent}", "Europe");
 
-        Assert.AreEqual(expected, result);
+        Assert.That(result, Is.EqualTo(expected));
         Console.WriteLine("DataRow: passed");
 
 
@@ -188,8 +191,11 @@ public class Message_SmartFormatter
         }
         catch (ParsingErrors ex)
         {
-            Assert.That(parsingErrors.Count == 1);
-            Assert.That(ex.Message.Contains("In: \"{lorem\""));
+            Assert.Multiple(() =>
+            {
+                Assert.That(parsingErrors.Count == 1);
+                Assert.That(ex.Message.Contains("In: \"{lorem\""));
+            });
             Console.WriteLine("Parsing error: passed");
         }
 
@@ -203,8 +209,8 @@ public class Message_SmartFormatter
 
         // ******** Culture ********
         result = smf.Format(culture, "{Date:d:MMMM}", new DateTime(2018,01,01));
-            
-        Assert.AreEqual("January", result);
+
+        Assert.That(result, Is.EqualTo("January"));
         Console.WriteLine("Culture: passed");
     }
 }

--- a/Src/MailMergeLib.Tests/Message_Templates.cs
+++ b/Src/MailMergeLib.Tests/Message_Templates.cs
@@ -17,25 +17,31 @@ class Message_Templates
 
         var msg = mmm.GetMimeMessage(variables);
 
-        Assert.AreEqual(mmm.Subject.Replace("{FirstName}", variables["FirstName"]), msg.Subject);
+        Assert.Multiple(() =>
+        {
+            Assert.That(msg.Subject, Is.EqualTo(mmm.Subject.Replace("{FirstName}", variables["FirstName"])));
 
-        // DefaultKey is "Formal"
-        Assert.IsTrue(msg.HtmlBody.Contains(mmm.Templates["Salutation"]["Formal"]
-            .First(t => t.Type == PartType.Html)
-            .Value.Replace("{FirstName}", variables["FirstName"])));
-        Assert.IsTrue(msg.TextBody.Contains(mmm.Templates["Salutation"]["Formal"]
-            .First(t => t.Type == PartType.Plain)
-            .Value.Replace("{FirstName}", variables["FirstName"])));
+            // DefaultKey is "Formal"
+            Assert.That(msg.HtmlBody.Contains(mmm.Templates["Salutation"]["Formal"]
+                .First(t => t.Type == PartType.Html)
+                .Value.Replace("{FirstName}", variables["FirstName"])), Is.True);
+            Assert.That(msg.TextBody.Contains(mmm.Templates["Salutation"]["Formal"]
+                .First(t => t.Type == PartType.Plain)
+                .Value.Replace("{FirstName}", variables["FirstName"])), Is.True);
+        });
 
         // Programmacically set the part to use
         mmm.Templates[0].Key = "Dear";
         msg = mmm.GetMimeMessage(variables);
-        Assert.IsTrue(msg.HtmlBody.Contains(mmm.Templates["Salutation"]["Dear"]
-            .First(t => t.Type == PartType.Html)
-            .Value.Replace("{FirstName}", variables["FirstName"])));
-        Assert.IsTrue(msg.TextBody.Contains(mmm.Templates["Salutation"]["Dear"]
-            .First(t => t.Type == PartType.Plain)
-            .Value.Replace("{FirstName}", variables["FirstName"])));
+        Assert.Multiple(() =>
+        {
+            Assert.That(msg.HtmlBody.Contains(mmm.Templates["Salutation"]["Dear"]
+                    .First(t => t.Type == PartType.Html)
+                    .Value.Replace("{FirstName}", variables["FirstName"])), Is.True);
+            Assert.That(msg.TextBody.Contains(mmm.Templates["Salutation"]["Dear"]
+                .First(t => t.Type == PartType.Plain)
+                .Value.Replace("{FirstName}", variables["FirstName"])), Is.True);
+        });
 
         // Neither DefaultKey nor Key of the template are set: gets the first part
         mmm.Templates[0].DefaultKey = null;
@@ -47,12 +53,15 @@ class Message_Templates
         mmm.Templates[0].Text.Remove(mmm.Templates[0].Text[2]);
 
         msg = mmm.GetMimeMessage(variables);
-        Assert.IsTrue(msg.HtmlBody.Contains(mmm.Templates["Salutation"]["Hi"]
-            .First(t => t.Type == PartType.Html)
-            .Value.Replace("{FirstName}", variables["FirstName"])));
-        Assert.IsTrue(msg.TextBody.Contains(mmm.Templates["Salutation"]["Hi"]
-            .First(t => t.Type == PartType.Plain)
-            .Value.Replace("{FirstName}", variables["FirstName"])));
+        Assert.Multiple(() =>
+        {
+            Assert.That(msg.HtmlBody.Contains(mmm.Templates["Salutation"]["Hi"]
+                    .First(t => t.Type == PartType.Html)
+                    .Value.Replace("{FirstName}", variables["FirstName"])), Is.True);
+            Assert.That(msg.TextBody.Contains(mmm.Templates["Salutation"]["Hi"]
+                .First(t => t.Type == PartType.Plain)
+                .Value.Replace("{FirstName}", variables["FirstName"])), Is.True);
+        });
     }
 
     [Test]
@@ -80,7 +89,7 @@ class Message_Templates
         var templates = mmm.Templates;
         var tempFilename = Path.GetTempFileName();
         templates.Serialize(tempFilename, Encoding.UTF8);
-        Assert.True(templates.Equals(Templates.Templates.Deserialize(tempFilename, Encoding.UTF8)!));
+        Assert.That(templates.Equals(Templates.Templates.Deserialize(tempFilename, Encoding.UTF8)!), Is.True);
         File.Delete(tempFilename);
     }
 
@@ -93,10 +102,12 @@ class Message_Templates
         templates.Serialize(stream, Encoding.UTF8);
         stream.Position = 0;
         var restoredTemplates = Templates.Templates.Deserialize(stream, Encoding.UTF8)!;
-        Assert.True(templates.Equals(restoredTemplates));
-
-        Assert.True(templates.Equals(templates));
-        Assert.False(templates.Equals(new object()));
+        Assert.Multiple(() =>
+        {
+            Assert.That(templates.Equals(restoredTemplates), Is.True);
+            Assert.That(templates.Equals(templates), Is.True);
+            Assert.That(templates.Equals(new object()), Is.False);
+        });
     }
 
     [Test]
@@ -106,14 +117,13 @@ class Message_Templates
         var t = mmm.Templates[0];
         Assert.DoesNotThrow(() =>
         {
-            Assert.IsTrue(t.GetParts(null).Length > 0);
+            Assert.That(t.GetParts(null).Length > 0, Is.True);
         });
         Assert.Throws<TemplateException>(() => t.Key = "This-is-definitely-an-illegal-Key-not-existing-in-any-Part");
-
-        Assert.False(t.Equals(new object()));
+        Assert.That(t.Equals(new object()), Is.False);
 
         // Equality with null members
         t.Key = t.DefaultKey = null;
-        Assert.False(t.Equals(new object()));
+        Assert.That(t.Equals(new object()), Is.False);
     }
 }

--- a/Src/MailMergeLib.Tests/Message_VariableExceptions.cs
+++ b/Src/MailMergeLib.Tests/Message_VariableExceptions.cs
@@ -40,14 +40,14 @@ class Message_VariableExceptions
              * 4) Missing file attachment {fileAtt.filename}.xml
              * 5) Missing inline attachment {inlineAtt.filename}.jpg
              */
-            Assert.AreEqual(5, exceptions.InnerExceptions.Count);
+            Assert.That(exceptions.InnerExceptions, Has.Count.EqualTo(5));
 
             foreach (var ex in exceptions.InnerExceptions.Where(ex => !(ex is MailMergeMessage
                          .AttachmentException)))
             {
                 if (ex is MailMergeMessage.VariableException exception)
                 {
-                    Assert.AreEqual(9, exception.MissingVariable.Count);
+                    Assert.That(exception.MissingVariable, Has.Count.EqualTo(9));
                     Console.WriteLine($"{nameof(MailMergeMessage.VariableException)} thrown successfully:");
                     Console.WriteLine("Missing variables: " +
                                       string.Join(", ",
@@ -67,14 +67,14 @@ class Message_VariableExceptions
             // one exception for a missing file attachment, one for a missing inline attachment
             var attExceptions = exceptions.InnerExceptions.Where(ex => ex is MailMergeMessage.AttachmentException)
                 .ToList();
-            Assert.AreEqual(2, attExceptions.Count);
+            Assert.That(attExceptions, Has.Count.EqualTo(2));
             foreach (var ex in attExceptions)
             {
                 Console.WriteLine($"{nameof(MailMergeMessage.AttachmentException)} thrown successfully:");
                 Console.WriteLine("Missing files: " +
                                   string.Join(", ", (ex as MailMergeMessage.AttachmentException)?.BadAttachment!));
                 Console.WriteLine();
-                Assert.AreEqual(1, (ex as MailMergeMessage.AttachmentException)?.BadAttachment.Count);
+                Assert.That((ex as MailMergeMessage.AttachmentException)?.BadAttachment.Count, Is.EqualTo(1));
             }
         }
 
@@ -95,8 +95,8 @@ class Message_VariableExceptions
              * 2) No recipients
              * 3) No FROM address
              */
-            Assert.AreEqual(3, exceptions.InnerExceptions.Count);
-            Assert.IsFalse(exceptions.InnerExceptions.Any(e => e is MailMergeMessage.AttachmentException));
+            Assert.That(exceptions.InnerExceptions, Has.Count.EqualTo(3));
+            Assert.That(exceptions.InnerExceptions.Any(e => e is MailMergeMessage.AttachmentException), Is.False);
 
             Console.WriteLine("Exceptions for missing attachment files suppressed.");
         }
@@ -109,25 +109,31 @@ class Message_VariableExceptions
 
         var msg = mmm.GetMimeMessage(variables);
 
-        Assert.AreEqual(mmm.Subject.Replace("{FirstName}", variables["FirstName"]), msg.Subject);
+        Assert.Multiple(() =>
+        {
+            Assert.That(msg.Subject, Is.EqualTo(mmm.Subject.Replace("{FirstName}", variables["FirstName"])));
 
-        // DefaultKey is "Formal"
-        Assert.IsTrue(msg.HtmlBody.Contains(mmm.Templates["Salutation"]["Formal"]
-            .First(t => t.Type == PartType.Html)
-            .Value.Replace("{FirstName}", variables["FirstName"])));
-        Assert.IsTrue(msg.TextBody.Contains(mmm.Templates["Salutation"]["Formal"]
-            .First(t => t.Type == PartType.Plain)
-            .Value.Replace("{FirstName}", variables["FirstName"])));
+            // DefaultKey is "Formal"
+            Assert.That(msg.HtmlBody.Contains(mmm.Templates["Salutation"]["Formal"]
+                .First(t => t.Type == PartType.Html)
+                .Value.Replace("{FirstName}", variables["FirstName"])), Is.True);
+            Assert.That(msg.TextBody.Contains(mmm.Templates["Salutation"]["Formal"]
+                .First(t => t.Type == PartType.Plain)
+                .Value.Replace("{FirstName}", variables["FirstName"])), Is.True);
+        });
 
         // Programmacically set the part to use
         mmm.Templates[0].Key = "Dear";
         msg = mmm.GetMimeMessage(variables);
-        Assert.IsTrue(msg.HtmlBody.Contains(mmm.Templates["Salutation"]["Dear"]
-            .First(t => t.Type == PartType.Html)
-            .Value.Replace("{FirstName}", variables["FirstName"])));
-        Assert.IsTrue(msg.TextBody.Contains(mmm.Templates["Salutation"]["Dear"]
-            .First(t => t.Type == PartType.Plain)
-            .Value.Replace("{FirstName}", variables["FirstName"])));
+        Assert.Multiple(() =>
+        {
+            Assert.That(msg.HtmlBody.Contains(mmm.Templates["Salutation"]["Dear"]
+                    .First(t => t.Type == PartType.Html)
+                    .Value.Replace("{FirstName}", variables["FirstName"])), Is.True);
+            Assert.That(msg.TextBody.Contains(mmm.Templates["Salutation"]["Dear"]
+                .First(t => t.Type == PartType.Plain)
+                .Value.Replace("{FirstName}", variables["FirstName"])), Is.True);
+        });
 
         // Neither DefaultKey nore Key of the template are set: gets the first part
         mmm.Templates[0].DefaultKey = null;
@@ -139,11 +145,14 @@ class Message_VariableExceptions
         mmm.Templates[0].Text.Remove(mmm.Templates[0].Text[2]);
 
         msg = mmm.GetMimeMessage(variables);
-        Assert.IsTrue(msg.HtmlBody.Contains(mmm.Templates["Salutation"]["Hi"]
-            .First(t => t.Type == PartType.Html)
-            .Value.Replace("{FirstName}", variables["FirstName"])));
-        Assert.IsTrue(msg.TextBody.Contains(mmm.Templates["Salutation"]["Hi"]
-            .First(t => t.Type == PartType.Plain)
-            .Value.Replace("{FirstName}", variables["FirstName"])));
+        Assert.Multiple(() =>
+        {
+            Assert.That(msg.HtmlBody.Contains(mmm.Templates["Salutation"]["Hi"]
+                    .First(t => t.Type == PartType.Html)
+                    .Value.Replace("{FirstName}", variables["FirstName"])), Is.True);
+            Assert.That(msg.TextBody.Contains(mmm.Templates["Salutation"]["Hi"]
+                .First(t => t.Type == PartType.Plain)
+                .Value.Replace("{FirstName}", variables["FirstName"])), Is.True);
+        });
     }
 }

--- a/Src/MailMergeLib.Tests/Sender_Config.cs
+++ b/Src/MailMergeLib.Tests/Sender_Config.cs
@@ -11,8 +11,11 @@ public class Sender_Config
         var sc1 = new SenderConfig();
         var sc2 = new SenderConfig();
 
-        Assert.IsTrue(sc1.Equals(sc2));
-        Assert.IsFalse(sc1.Equals(new object()));
+        Assert.Multiple(() =>
+        {
+            Assert.That(sc1.Equals(sc2), Is.True);
+            Assert.That(sc1.Equals(new object()), Is.False);
+        });
     }
 
     [Test]
@@ -21,7 +24,10 @@ public class Sender_Config
         var sc1 = new SenderConfig();
         var sc2 = new SenderConfig {MaxNumOfSmtpClients = 99999 };
 
-        Assert.IsFalse(sc1.Equals(sc2));
-        Assert.IsFalse(sc1.Equals(new object()));
+        Assert.Multiple(() =>
+        {
+            Assert.That(sc1.Equals(sc2), Is.False);
+            Assert.That(sc1.Equals(new object()), Is.False);
+        });
     }
 }

--- a/Src/MailMergeLib.Tests/Settings_Serialization.cs
+++ b/Src/MailMergeLib.Tests/Settings_Serialization.cs
@@ -91,7 +91,7 @@ public class Settings_Serialization
         const string newKey = "some-random-key-for-testing";
         var oldValue = Settings.CryptoKey;
         Settings.CryptoKey = newKey;
-        Assert.AreEqual(newKey, Settings.CryptoKey);
+        Assert.That(Settings.CryptoKey, Is.EqualTo(newKey));
         Settings.CryptoKey = oldValue;
     }
 
@@ -100,8 +100,11 @@ public class Settings_Serialization
     {
         var credential = (Credential?)_outSettings.SenderConfig.SmtpClientConfig.First().NetworkCredential;
         var networkCredential = credential?.GetCredential(new Uri("file:///"), "");
-        Assert.AreEqual(credential?.Username, networkCredential?.UserName);
-        Assert.AreEqual(credential?.Password, networkCredential?.Password);
+        Assert.Multiple(() =>
+        {
+            Assert.That(networkCredential?.UserName, Is.EqualTo(credential?.Username));
+            Assert.That(networkCredential?.Password, Is.EqualTo(credential?.Password));
+        });
     }
 
     [Test]
@@ -109,9 +112,12 @@ public class Settings_Serialization
     {
         var credential = (Credential?)_outSettings.SenderConfig.SmtpClientConfig.Last().NetworkCredential;
         var networkCredential = credential?.GetCredential(new Uri("file:///"), "");
-        Assert.AreEqual(credential?.Username, networkCredential?.UserName);
-        Assert.AreEqual(credential?.Password, networkCredential?.Password);
-        Assert.AreEqual(credential?.Domain, networkCredential?.Domain);
+        Assert.Multiple(() =>
+        {
+            Assert.That(networkCredential?.UserName, Is.EqualTo(credential?.Username));
+            Assert.That(networkCredential?.Password, Is.EqualTo(credential?.Password));
+            Assert.That(networkCredential?.Domain, Is.EqualTo(credential?.Domain));
+        });
     }
 
     [Test]
@@ -125,11 +131,11 @@ public class Settings_Serialization
         _outSettings.Serialize(outMs, Encoding.UTF8);
         var inSettings = Settings.Deserialize(outMs, Encoding.UTF8);
 
-        Assert.IsTrue(inSettings?.SenderConfig.Equals(_outSettings.SenderConfig));
+        Assert.That(inSettings?.SenderConfig.Equals(_outSettings.SenderConfig), Is.True);
         outMs.Dispose();
 
         var smtpCredential = (Credential?) _outSettings.SenderConfig.SmtpClientConfig.First().NetworkCredential;
-        Assert.AreEqual(cryptoEnabled, smtpCredential?.Password != smtpCredential?.PasswordEncrypted && smtpCredential?.Username != smtpCredential?.UsernameEncrypted);
+        Assert.That(smtpCredential?.Password != smtpCredential?.PasswordEncrypted && smtpCredential?.Username != smtpCredential?.UsernameEncrypted, Is.EqualTo(cryptoEnabled));
     }
 
     [Test]
@@ -142,10 +148,10 @@ public class Settings_Serialization
         var serialized = _outSettings.Serialize();
         var restored = Settings.Deserialize(serialized)!;
 
-        Assert.IsTrue(restored.SenderConfig.Equals(_outSettings.SenderConfig));
+        Assert.That(restored.SenderConfig.Equals(_outSettings.SenderConfig), Is.True);
 
         var smtpCredential = (Credential?)_outSettings.SenderConfig.SmtpClientConfig.First().NetworkCredential;
-        Assert.AreEqual(cryptoEnabled, smtpCredential?.Password != smtpCredential?.PasswordEncrypted && smtpCredential?.Username != smtpCredential?.UsernameEncrypted);
+        Assert.That(smtpCredential?.Password != smtpCredential?.PasswordEncrypted && smtpCredential?.Username != smtpCredential?.UsernameEncrypted, Is.EqualTo(cryptoEnabled));
     }
 
     [Test]

--- a/Src/MailMergeLib.Tests/SmtpClient_Config.cs
+++ b/Src/MailMergeLib.Tests/SmtpClient_Config.cs
@@ -30,12 +30,15 @@ namespace MailMergeLib.Tests
             ChangeSmtpConfigFile(smtpSettings);
             smtpConfig.ReadSmtpConfigurationFromConfigFile();
 
-            Assert.AreEqual(smtpDeliveryMethod == SmtpDeliveryMethod.Network ? MessageOutput.SmtpServer :
-                smtpDeliveryMethod == SmtpDeliveryMethod.PickupDirectoryFromIis ? MessageOutput.PickupDirectoryFromIis :
-                smtpDeliveryMethod == SmtpDeliveryMethod.SpecifiedPickupDirectory ? MessageOutput.Directory :
-                MessageOutput.None, smtpConfig.MessageOutput);
+            Assert.Multiple(() =>
+            {
+                Assert.That(smtpConfig.MessageOutput, Is.EqualTo(smtpDeliveryMethod == SmtpDeliveryMethod.Network ? MessageOutput.SmtpServer :
+                            smtpDeliveryMethod == SmtpDeliveryMethod.PickupDirectoryFromIis ? MessageOutput.PickupDirectoryFromIis :
+                            smtpDeliveryMethod == SmtpDeliveryMethod.SpecifiedPickupDirectory ? MessageOutput.Directory :
+                            MessageOutput.None));
 
-            Assert.AreEqual(enableSsl ? MailKit.Security.SecureSocketOptions.Auto : MailKit.Security.SecureSocketOptions.None, smtpConfig.SecureSocketOptions);
+                Assert.That(smtpConfig.SecureSocketOptions, Is.EqualTo(enableSsl ? MailKit.Security.SecureSocketOptions.Auto : MailKit.Security.SecureSocketOptions.None));
+            });
         }
 
         [Test]
@@ -43,7 +46,7 @@ namespace MailMergeLib.Tests
         [TestCase("", "password", false)]
         [TestCase("user", "", false)]
         [TestCase(null, null, false)]
-        public void Read_SmtpConfig_From_ConfigFile(string username, string password, bool credentialSet)
+        public void Read_SmtpConfig_From_ConfigFile(string? username, string? password, bool credentialSet)
         {
             var smtpConfig = new SmtpClientConfig();
             var smtpSettings = new SmtpSection()
@@ -53,28 +56,31 @@ namespace MailMergeLib.Tests
             ChangeSmtpConfigFile(smtpSettings);
             smtpConfig.ReadSmtpConfigurationFromConfigFile();
 
-            Assert.AreEqual(credentialSet, smtpConfig.NetworkCredential != null);
+            Assert.That(smtpConfig.NetworkCredential != null, Is.EqualTo(credentialSet));
             if (credentialSet)
             {
-                Assert.AreEqual(username, ((Credential?) smtpConfig.NetworkCredential)?.Username);
-                Assert.AreEqual(password, ((Credential?) smtpConfig.NetworkCredential)?.Password);
+                Assert.Multiple(() =>
+                {
+                    Assert.That(((Credential?) smtpConfig.NetworkCredential)?.Username, Is.EqualTo(username));
+                    Assert.That(((Credential?) smtpConfig.NetworkCredential)?.Password, Is.EqualTo(password));
+                });
             }
         }
 
         [Test]
         [TestCase("host", 25, "domain")]
         [TestCase(null, 123, null)]
-        public void Read_SmtpConfig_From_ConfigFile(string host, int port, string clientDomain)
+        public void Read_SmtpConfig_From_ConfigFile(string? host, int port, string? clientDomain)
         {
             var smtpConfig = new SmtpClientConfig();
-            var smtpSettings = new SmtpSection()
+            var smtpSettings = new SmtpSection
             {
                 Network = { Host = host, Port = port, ClientDomain = clientDomain}
             };
             ChangeSmtpConfigFile(smtpSettings);
             smtpConfig.ReadSmtpConfigurationFromConfigFile();
 
-            Assert.IsTrue(smtpConfig.SmtpHost == host && smtpConfig.SmtpPort == port && smtpConfig.ClientDomain == clientDomain);
+            Assert.That(smtpConfig.SmtpHost == host && smtpConfig.SmtpPort == port && smtpConfig.ClientDomain == clientDomain, Is.True);
         }
 
         /// <summary>
@@ -121,7 +127,7 @@ namespace MailMergeLib.Tests
             {
                 MessageOutput = MessageOutput.Directory
             };
-            Assert.AreEqual(System.IO.Path.GetTempPath(), smtpConfig.MailOutputDirectory);
+            Assert.That(smtpConfig.MailOutputDirectory, Is.EqualTo(System.IO.Path.GetTempPath()));
         }
 
         [Test]
@@ -130,8 +136,11 @@ namespace MailMergeLib.Tests
             var sc1 = new SmtpClientConfig();
             var sc2 = new SmtpClientConfig();
 
-            Assert.IsTrue(sc1.Equals(sc2));
-            Assert.IsFalse(sc1.Equals(new object()));
+            Assert.Multiple(() =>
+            {
+                Assert.That(sc1.Equals(sc2), Is.True);
+                Assert.That(sc1.Equals(new object()), Is.False);
+            });
         }
 
         [Test]
@@ -140,8 +149,11 @@ namespace MailMergeLib.Tests
             var sc1 = new SmtpClientConfig();
             var sc2 = new SmtpClientConfig { SmtpPort = 12345 };
 
-            Assert.IsFalse(sc1.Equals(sc2));
-            Assert.IsFalse(sc1.Equals(new object()));
+            Assert.Multiple(() =>
+            {
+                Assert.That(sc1.Equals(sc2), Is.False);
+                Assert.That(sc1.Equals(new object()), Is.False);
+            });
         }
     }
 }

--- a/Src/MailMergeLib.Tests/TestSetup.cs
+++ b/Src/MailMergeLib.Tests/TestSetup.cs
@@ -2,7 +2,7 @@
 using System.IO;
 using NUnit.Framework;
 
-namespace YAXLibTests;
+namespace MailMergeLib.Tests;
 
 [SetUpFixture]
 public class TestSetup

--- a/Src/MailMergeLib.Tests/Tools.cs
+++ b/Src/MailMergeLib.Tests/Tools.cs
@@ -34,21 +34,21 @@ public class Tools
         [TestCase(@"C:\inval|d", false, false, ExcludePlatform="Linux")]
         [TestCase(@"\\is_this_a_dir_or_a_hostname", false, false, ExcludePlatform="Linux")]
 #endif
-    public static void IsFullPath(string path, bool expectedIsFull, bool expectedIsValid = true)
+    public static void IsFullPath(string? path, bool expectedIsFull, bool expectedIsValid = true)
     {
-        Assert.AreEqual(expectedIsFull, MailMergeLib.Tools.IsFullPath(path), "IsFullPath('" + path + "')");
+        Assert.That(MailMergeLib.Tools.IsFullPath(path ?? string.Empty), Is.EqualTo(expectedIsFull), "IsFullPath('" + path + "')");
 
         if (expectedIsFull)
         {
-            Assert.AreEqual(path, Path.GetFullPath(path));
+            Assert.That(Path.GetFullPath(path ?? string.Empty), Is.EqualTo(path));
         }
         else if (expectedIsValid)
         {
-            Assert.AreNotEqual(path, Path.GetFullPath(path));
+            Assert.That(Path.GetFullPath(path ?? string.Empty), Is.Not.EqualTo(path ?? string.Empty));
         }
         else
         {
-            Assert.That(() => Path.GetFullPath(path), Throws.Exception);
+            Assert.That(() => Path.GetFullPath(path ?? string.Empty), Throws.Exception);
         }
     }
 
@@ -61,12 +61,12 @@ public class Tools
     [TestCase(@"folder2/folder3", @"folder1/", @"folder1/folder2/folder3", IncludePlatform="Linux")]
     public void RelativePathTo(string expected, string from, string to)
     {
-        Assert.AreEqual(expected, MailMergeLib.Tools.RelativePathTo(from, to));
+        Assert.That(MailMergeLib.Tools.RelativePathTo(from, to), Is.EqualTo(expected));
     }
 
     [Test]
     [TestCase(null, @"C:\Temp", @"D:\", ExcludePlatform="Linux")]
-    public void RelativePathTo_Different_Path_Roots(string expected, string from, string to)
+    public void RelativePathTo_Different_Path_Roots(string? expected, string from, string to)
     {
         Assert.Throws<ArgumentException>(() => { MailMergeLib.Tools.RelativePathTo(from, to); });
     }
@@ -74,7 +74,7 @@ public class Tools
     [Test]
     [TestCase(null, @"folder1\", @"folder2", ExcludePlatform="Linux")]
     [TestCase(null, @"folder1/", @"folder2", IncludePlatform="Linux")]
-    public void RelativePathTo_No_Common_Prefix_Path(string expected, string from, string to)
+    public void RelativePathTo_No_Common_Prefix_Path(string? expected, string from, string to)
     {
         Assert.Throws<ArgumentException>(() => { MailMergeLib.Tools.RelativePathTo(from, to); });
     }
@@ -82,9 +82,9 @@ public class Tools
     [Test]
     [TestCase(null, null, "")]
     [TestCase(null, "", null)]
-    public void RelativePathTo_NullTests(string expected, string from, string to)
+    public void RelativePathTo_NullTests(string? expected, string? from, string? to)
     {
-        Assert.Throws<ArgumentNullException>(() => { MailMergeLib.Tools.RelativePathTo(from, to); });
+        Assert.Throws<ArgumentNullException>(() => { MailMergeLib.Tools.RelativePathTo(from!, to!); });
     }
 
 
@@ -93,7 +93,7 @@ public class Tools
     [TestCase(false, "abcdeföäü")]
     public void IsSevenBit(bool expected, string toTest)
     {
-        Assert.AreEqual(expected, MailMergeLib.Tools.IsSevenBit(toTest));
+        Assert.That(MailMergeLib.Tools.IsSevenBit(toTest), Is.EqualTo(expected));
     }
 
     [Test]
@@ -102,7 +102,7 @@ public class Tools
     public void IsSevenBitStream(bool expected, string toTest)
     {
         using var stream = new MemoryStream(System.Text.Encoding.UTF8.GetBytes(toTest ?? string.Empty));
-        Assert.AreEqual(expected, MailMergeLib.Tools.IsSevenBit(stream));
+        Assert.That(MailMergeLib.Tools.IsSevenBit(stream), Is.EqualTo(expected));
     }
 
     [Test]
@@ -110,14 +110,14 @@ public class Tools
     public void StreamToString(string toTest)
     {
         using var stream = new MemoryStream(System.Text.Encoding.UTF8.GetBytes(toTest ?? string.Empty));
-        Assert.AreEqual(toTest, MailMergeLib.Tools.Stream2String(stream));
+        Assert.That(MailMergeLib.Tools.Stream2String(stream), Is.EqualTo(toTest));
     }
 
     [Test]
     public void WrapLines()
     {
         var text = "this is a number of words in one line which will be wrapped 1234567890 1234";
-        Assert.AreEqual(9, MailMergeLib.Tools.WrapLines(text, 10).Split(new []{ '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries).Length);
+        Assert.That(MailMergeLib.Tools.WrapLines(text, 10).Split(new []{ '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries).Length, Is.EqualTo(9));
     }
 
     [Test]
@@ -126,8 +126,11 @@ public class Tools
     public void ParseMailAddress(string toTest, string expectedEmail, string expectedDisplayName)
     {
         MailMergeLib.Tools.ParseMailAddress(toTest, out var displayName, out var email);
-        Assert.AreEqual(expectedEmail, email);
-        Assert.AreEqual(expectedDisplayName, displayName);
+        Assert.Multiple(() =>
+        {
+            Assert.That(email, Is.EqualTo(expectedEmail));
+            Assert.That(displayName, Is.EqualTo(expectedDisplayName));
+        });
     }
 
     [Test]
@@ -144,7 +147,7 @@ public class Tools
 #endif
     public void GetMimeCharset(string expected, string encoding)
     {
-        Assert.AreEqual(expected, MailMergeLib.Tools.GetMimeCharset(Encoding.GetEncoding(encoding)));
+        Assert.That(MailMergeLib.Tools.GetMimeCharset(Encoding.GetEncoding(encoding)), Is.EqualTo(expected));
         Assert.Throws<ArgumentNullException>(() => MailMergeLib.Tools.GetMimeCharset(null));
     }
 }

--- a/Src/MailMergeLib/MailMergeLib.csproj
+++ b/Src/MailMergeLib/MailMergeLib.csproj
@@ -56,10 +56,10 @@ https://github.com/axuno/MailMergeLib/releases</PackageReleaseNotes>
 
     <ItemGroup>
         <PackageReference Include="AngleSharp" Version="1.1.2" />
-        <PackageReference Include="MailKit" Version="4.6.0" />
-        <PackageReference Include="MimeKit" Version="4.6.0" />
+        <PackageReference Include="MailKit" Version="4.7.1.1" />
+        <PackageReference Include="MimeKit" Version="4.7.1" />
         <PackageReference Include="SmartFormat.NET" Version="3.4.0" />
-        <PackageReference Include="YAXLib" Version="4.2.2" />
+        <PackageReference Include="YAXLib" Version="4.3.0" />
         <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/Src/MailMergeLib/Serialization/MailMergeAddressesSerializer.cs
+++ b/Src/MailMergeLib/Serialization/MailMergeAddressesSerializer.cs
@@ -36,11 +36,13 @@ internal class MailMergeAddressesSerializer : ICustomSerializer<MailMergeAddress
     {
         var addrColl = new MailMergeAddressCollection();
         var serializer = SerializationFactory.GetStandardSerializer(typeof(MailMergeAddressCollection));
-        var result = serializer.Deserialize(element) as List<object>;
-        if (result == null) return addrColl;
-        foreach (MailMergeAddress addr in result)
+
+        if (serializer.Deserialize(element) is not IEnumerable<MailMergeAddress> result)
+            return addrColl;
+        
+        foreach (var address in result)
         {
-            addrColl.AddWithCurrentCharacterEncoding(addr);
+            addrColl.AddWithCurrentCharacterEncoding(address);
         }
         return addrColl;
     }

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-version: 5.11.1.{build} # Only change for mayor versions (e.g. 6.0.0)
+version: 5.12.0.{build} # Only change for mayor versions (e.g. 6.0.0)
 environment:
   DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true 
   matrix:


### PR DESCRIPTION
#### PR Classification
This pull request focuses on code cleanup and modernization, specifically by enhancing test readability and consistency, adopting newer C# features, and updating dependencies.

#### PR Summary
The pull request modernizes the test suite and codebase of the MailMergeLib project by refactoring assertion syntax for better readability, adopting C# 8.0 nullable reference types, and updating NuGet package versions. Key changes include:
- Refactored assertion syntax across multiple test classes to use `Assert.That` with the NUnit constraint model.
- Introduced `Assert.Multiple` blocks in test methods for grouped assertion evaluation.
- Updated method signatures to accept nullable reference types, reflecting adoption of C# 8.0 features.
- Removed `netcoreapp3.1` target framework and updated various NuGet package references in `MailMergeLib.Tests.csproj`.
- Added `NUnit.Analyzers` reference in `MailMergeLib.Tests.csproj` for enhanced test writing assistance.

#### Package Updates

MailMergeLib package updates
* MimeKit v4.6.0 => v4.7.1.1
* MailKit v4.6.0 => 4.7.1
* YAXLib v4.2.2 => v4.3.0

Unit test package updates
* Microsoft.NET.Test.Sdk 17.6.3 => 17.10.0
* NUnit v3.13.3 => v4.1.0
* Drop NetCore3.1
* Add Nunit.Analyzers v4.2.0