### PR TITLE
Improve HTML processing for placeholders that are using formatting arguments

### DIFF
--- a/Src/Directory.Build.props
+++ b/Src/Directory.Build.props
@@ -8,8 +8,8 @@
         <Copyright>Copyright 2011-$(CurrentYear) axuno, MailMergeLib Project maintainers and contributers</Copyright>
         <RepositoryUrl>https://github.com/axuno/MailMergeLib.git</RepositoryUrl>
         <PublishRepositoryUrl>true</PublishRepositoryUrl>
-        <Version>5.12.0</Version>
-        <FileVersion>5.12.0</FileVersion>
+        <Version>5.12.2</Version>
+        <FileVersion>5.12.2</FileVersion>
         <AssemblyVersion>5.0.0.0</AssemblyVersion> <!--only update AssemblyVersion with major releases -->
         <LangVersion>latest</LangVersion>
         <EnableNETAnalyzers>true</EnableNETAnalyzers>

--- a/Src/MailMergeLib.Tests/MailMergeLib.Tests.csproj
+++ b/Src/MailMergeLib.Tests/MailMergeLib.Tests.csproj
@@ -8,7 +8,6 @@
         <AssemblyName>MailMergeLib.Tests</AssemblyName>
         <AssemblyOriginatorKeyFile>../MailMergeLib/MailMergeLib.snk</AssemblyOriginatorKeyFile>
         <SignAssembly>true</SignAssembly>
-        <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>
         <IsTestProject>true</IsTestProject>
         <Nullable>enable</Nullable>
         <LangVersion>latest</LangVersion>

--- a/Src/MailMergeLib.Tests/Message_Html.cs
+++ b/Src/MailMergeLib.Tests/Message_Html.cs
@@ -5,7 +5,6 @@ using System.Linq;
 using AngleSharp.Html.Dom;
 using AngleSharp.Html.Parser;
 using MimeKit;
-using Newtonsoft.Json.Linq;
 using NUnit.Framework;
 
 namespace MailMergeLib.Tests;
@@ -351,7 +350,19 @@ public class Message_Html
         mmm.MailMergeAddresses.Add(new MailMergeAddress(MailAddressType.From, "no-reply@specimen.com"));
         var dataItem = new { Name = "John", Value = 2 };
         var msg = mmm.GetMimeMessage(dataItem);
-        Assert.That(msg.HtmlBody.Contains(dataItem.Name), Is.True);
+        Assert.That(msg.HtmlBody, Does.Contain(dataItem.Name));
+    }
+
+    [Test]
+    public void HtmlBodyBuilder()
+    {
+        using var mmm = new MailMergeMessage("subject", "plain text", "<html><head></head><body>{Name}{Value:0.00}</body></html>");
+        mmm.MailMergeAddresses.Add(new MailMergeAddress(MailAddressType.To, "john@specimen.com"));
+        mmm.MailMergeAddresses.Add(new MailMergeAddress(MailAddressType.From, "no-reply@specimen.com"));
+        var dataItem = new { Name = "John", Value = 2 };
+        var bb = new HtmlBodyBuilder(mmm, dataItem);
+
+        Assert.That(bb.DocHtml, Does.Contain(dataItem.Name));
     }
 
     [TestCase("John", 0, "John: Nothing")]

--- a/Src/MailMergeLib.Tests/Message_Html.cs
+++ b/Src/MailMergeLib.Tests/Message_Html.cs
@@ -31,10 +31,10 @@ public class Message_Html
             var mimeMessage = mmm.GetMimeMessage(null);
 
             var size = MailMergeLib.Tools.CalcMessageSize(mimeMessage);
-            Assert.That(size > 0, Is.True);
+            Assert.That(size, Is.GreaterThan(0));
         }
 
-        Assert.That(MailMergeLib.Tools.CalcMessageSize(null) == 0, Is.True);
+        Assert.That(MailMergeLib.Tools.CalcMessageSize(null), Is.EqualTo(0));
     }
 
     [Test]
@@ -105,16 +105,24 @@ public class Message_Html
 
         Assert.Multiple(() =>
         {
-            Assert.That(((MailboxAddress) msg.From.First()).Address == dataItem.SenderAddr, Is.True);
-            Assert.That(((MailboxAddress) msg.To.First()).Address == dataItem.MailboxAddr, Is.True);
-            Assert.That(((MailboxAddress) msg.To.First()).Name == dataItem.Name, Is.True);
-            Assert.That(msg.Headers[HeaderId.Organization] == mmm.Config.Organization, Is.True);
-            Assert.That(msg.Priority == mmm.Config.Priority, Is.True);
-            Assert.That(msg.Attachments.FirstOrDefault(a => ((MimePart) a).FileName == "Log file from {Date:yyyy-MM-dd}.log".Replace("{Date:yyyy-MM-dd}", dataItem.Date.ToString("yyyy-MM-dd"))) != null, Is.True);
-            Assert.That(msg.Subject == mmm.Subject.Replace("{Date:yyyy-MM-dd}", dataItem.Date.ToString("yyyy-MM-dd")), Is.True);
-            Assert.That(msg.HtmlBody.Contains(dataItem.Success ? "succeeded" : "failed"), Is.True);
-            Assert.That(msg.TextBody.Contains(dataItem.Success ? "succeeded" : "failed"), Is.True);
-            Assert.That(msg.BodyParts.Any(bp => bp.ContentDisposition?.Disposition == ContentDisposition.Inline && bp.ContentType.IsMimeType("image", "jpeg")), Is.True);
+            Assert.That(((MailboxAddress) msg.From.First()).Address, Is.EqualTo(dataItem.SenderAddr));
+            Assert.That(((MailboxAddress) msg.To.First()).Address, Is.EqualTo(dataItem.MailboxAddr));
+            Assert.That(((MailboxAddress) msg.To.First()).Name, Is.EqualTo(dataItem.Name));
+            Assert.That(msg.Headers[HeaderId.Organization], Is.EqualTo(mmm.Config.Organization));
+            Assert.That(msg.Priority, Is.EqualTo(mmm.Config.Priority));
+            Assert.That(
+                msg.Attachments.FirstOrDefault(a =>
+                    ((MimePart) a).FileName ==
+                    "Log file from {Date:yyyy-MM-dd}.log".Replace("{Date:yyyy-MM-dd}",
+                        dataItem.Date.ToString("yyyy-MM-dd"))), Is.Not.EqualTo(null));
+            Assert.That(msg.Subject,
+                Is.EqualTo(mmm.Subject.Replace("{Date:yyyy-MM-dd}", dataItem.Date.ToString("yyyy-MM-dd"))));
+            Assert.That(msg.HtmlBody, Does.Contain(dataItem.Success ? "succeeded" : "failed"));
+            Assert.That(msg.TextBody, Does.Contain(dataItem.Success ? "succeeded" : "failed"));
+            Assert.That(
+                msg.BodyParts.Any(bp =>
+                    bp.ContentDisposition?.Disposition == ContentDisposition.Inline &&
+                    bp.ContentType.IsMimeType("image", "jpeg")), Is.True);
         });
 
         MailMergeMessage.DisposeFileStreams(msg);
@@ -134,12 +142,12 @@ public class Message_Html
             mmm.StreamAttachments.Add(new StreamAttachment(stream, streamAttFilename, "text/plain"));
         }
 
-        Assert.That(mmm.StreamAttachments.Count == 1, Is.True);
+        Assert.That(mmm.StreamAttachments.Count, Is.EqualTo(1));
         mmm.StreamAttachments.Clear();
-        Assert.That(mmm.StreamAttachments.Count == 0, Is.True);
+        Assert.That(mmm.StreamAttachments.Count, Is.EqualTo(0));
 
         mmm.StreamAttachments = streamAttachments;
-        Assert.That(mmm.StreamAttachments.Count == 2, Is.True);
+        Assert.That(mmm.StreamAttachments.Count, Is.EqualTo(2));
     }
 
 
@@ -199,8 +207,8 @@ public class Message_Html
 
         Assert.Multiple(() =>
         {
-            Assert.That(new HtmlParser().ParseDocument((string) msg.HtmlBody).All.Count(m => m is IHtmlImageElement) == 3, Is.True);
-            Assert.That(msg.BodyParts.Count(bp => bp.ContentDisposition?.Disposition == ContentDisposition.Inline && bp.ContentType.IsMimeType("image", "jpeg")) == 1, Is.True);
+            Assert.That(new HtmlParser().ParseDocument((string) msg.HtmlBody).All.Count(m => m is IHtmlImageElement), Is.EqualTo(3));
+            Assert.That(msg.BodyParts.Count(bp => bp.ContentDisposition?.Disposition == ContentDisposition.Inline && bp.ContentType.IsMimeType("image", "jpeg")), Is.EqualTo(1));
         });
 
         MailMergeMessage.DisposeFileStreams(msg);

--- a/Src/MailMergeLib/BodyBuilderBase.cs
+++ b/Src/MailMergeLib/BodyBuilderBase.cs
@@ -25,7 +25,7 @@ internal abstract class BodyBuilderBase
     public ContentEncoding TextTransferEncoding { get; set; }
 
     /// <summary>
-    /// Gets the ready made body part for a mail message.
+    /// Gets the ready-made body part for a mail message.
     /// </summary>
     public abstract MimeEntity GetBodyPart();
 }

--- a/Src/MailMergeLib/MailMergeMessage.cs
+++ b/Src/MailMergeLib/MailMergeMessage.cs
@@ -340,6 +340,10 @@ public partial class MailMergeMessage : IDisposable
         var currentSmartSettings = invokedFromConstructor
             ? new SmartSettings()
             : SmartFormatter.Settings;
+        // Parse content of <script> and <style> tags as literal text, 
+        // i.e. placeholder parsing is disabled for these tags
+        currentSmartSettings.Parser.ParseInputAsHtml = true;
+
         var smartFormatter = new MailSmartFormatter(Config.SmartFormatterConfig, currentSmartSettings);
         smartFormatter.OnFormattingFailure += (sender, args) => { _badVariableNames.Add(args.Placeholder); };
         smartFormatter.Parser.OnParsingFailure += (sender, args) => { _parseExceptions.Add(new ParseException(args.Errors.MessageShort, args.Errors)); };
@@ -356,7 +360,7 @@ public partial class MailMergeMessage : IDisposable
     /// <remarks>
     /// In case <see cref="SmartFormat.Core.Settings.SmartSettings.FormatErrorAction"/> == ErrorAction.ThrowError
     /// or <see cref="SmartFormat.Core.Settings.SmartSettings.ParseErrorAction"/> == ErrorAction.ThrowError
-    /// we simple catch the exception and simulate setting ErrorAction.MaintainTokens.
+    /// we simply catch the exception and simulate setting ErrorAction.MaintainTokens.
     /// Note: We track such errors by subscribing to Parser.OnParsingFailure and Formatter.OnFormattingFailure.
     /// </remarks>
     internal string SearchAndReplaceVars(string text, object? dataItem)
@@ -390,7 +394,7 @@ public partial class MailMergeMessage : IDisposable
     /// <remarks>
     /// In case <see cref="SmartFormat.Core.Settings.SmartSettings.FormatErrorAction"/> == ErrorAction.ThrowError
     /// or <see cref="SmartFormat.Core.Settings.SmartSettings.ParseErrorAction"/> == ErrorAction.ThrowError
-    /// we simple catch the exception and simulate setting ErrorAction.MaintainTokens.
+    /// we simply catch the exception and simulate setting ErrorAction.MaintainTokens.
     /// Note: We track such errors by subscribing to Parser.OnParsingFailure and Formatter.OnFormattingFailure.
     /// </remarks>
     internal string SearchAndReplaceVarsInFilename(string text, object? dataItem)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-version: 5.12.1.{build} # Only change for mayor versions (e.g. 6.0.0)
+version: 5.12.2.{build} # Only change for mayor versions (e.g. 6.0.0)
 environment:
   DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true 
   matrix:
@@ -27,7 +27,7 @@ for:
       - ps: dotnet restore --verbosity quiet
       - ps: dotnet add .\MailMergeLib.Tests\MailMergeLib.Tests.csproj package AltCover
       - ps: |
-          $version = "5.12.1"
+          $version = "5.12.2"
           $versionFile = $version + "." + ${env:APPVEYOR_BUILD_NUMBER}
 
           if ($env:APPVEYOR_PULL_REQUEST_NUMBER) {


### PR DESCRIPTION
Resolves #45 
- Modified `HtmlBodyBuilder` constructor to replace placeholders before parsing HTML to avoid entity encoding issues.
- Simplified `ReplaceImgSrcByCid` method in `HtmlBodyBuilder.cs`.
- Updated `GetConfiguredMailSmartFormatter` in `MailMergeMessage.cs` to set `ParseInputAsHtml` to `true`.
- Introduced new test methods `SimpleHtmlContent` and `ConditionalHtmlContent` in `Message_Html.cs`.
- Corrected typos in comments