### PR TITLE
Update referenced packages

### DIFF
--- a/Src/MailMergeLib.Tests/MailMergeLib.Tests.csproj
+++ b/Src/MailMergeLib.Tests/MailMergeLib.Tests.csproj
@@ -3,7 +3,7 @@
     <PropertyGroup>
         <Description>Test project for MailMergeLib</Description>
         <AssemblyTitle>MailMergeLib.UnitTest</AssemblyTitle>
-        <TargetFrameworks>net462;net6.0</TargetFrameworks>
+        <TargetFrameworks>net462;net8.0</TargetFrameworks>
         <GenerateDocumentationFile>false</GenerateDocumentationFile>
         <AssemblyName>MailMergeLib.Tests</AssemblyName>
         <AssemblyOriginatorKeyFile>../MailMergeLib/MailMergeLib.snk</AssemblyOriginatorKeyFile>
@@ -33,16 +33,16 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageReference Include="Microsoft.DotNet.PlatformAbstractions" Version="3.1.6" />
-    <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="8.0.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="9.0.9" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.0" />
     <PackageReference Include="netDumbster" Version="3.1.1" />
-    <PackageReference Include="NUnit" Version="4.1.0" />
-    <PackageReference Include="NUnit.Analyzers" Version="4.2.0">
+    <PackageReference Include="NUnit" Version="4.4.0" />
+    <PackageReference Include="NUnit.Analyzers" Version="4.10.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="NUnit3TestAdapter" Version="4.6.0" />
-    <PackageReference Include="System.ValueTuple" Version="4.5.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="5.1.0" />
+    <PackageReference Include="System.ValueTuple" Version="4.6.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Src/MailMergeLib/MailMergeLib.csproj
+++ b/Src/MailMergeLib/MailMergeLib.csproj
@@ -55,10 +55,10 @@ https://github.com/axuno/MailMergeLib/releases</PackageReleaseNotes>
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="AngleSharp" Version="1.1.2" />
-        <PackageReference Include="MailKit" Version="4.7.1.1" />
-        <PackageReference Include="MimeKit" Version="4.7.1" />
-        <PackageReference Include="SmartFormat.NET" Version="3.5.0" />
+        <PackageReference Include="AngleSharp" Version="1.3.0" />
+        <PackageReference Include="MailKit" Version="4.14.0" />
+        <PackageReference Include="MimeKit" Version="4.14.0" />
+        <PackageReference Include="SmartFormat.NET" Version="3.6.1" />
         <PackageReference Include="YAXLib" Version="4.3.0" />
         <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0">
             <PrivateAssets>all</PrivateAssets>
@@ -68,7 +68,7 @@ https://github.com/axuno/MailMergeLib/releases</PackageReleaseNotes>
 
     <ItemGroup Condition=" '$(TargetFramework)' == 'net462' ">
         <Reference Include="System.Configuration" />
-        <PackageReference Include="System.Configuration.ConfigurationManager" Version="8.0.0" />
+        <PackageReference Include="System.Configuration.ConfigurationManager" Version="9.0.9" />
         <PackageReference Include="System.Text.Encoding.Extensions" Version="4.3.0" />
     </ItemGroup>
 

--- a/Src/MailMergeLib/Tools.cs
+++ b/Src/MailMergeLib/Tools.cs
@@ -166,7 +166,9 @@ public static class Tools
         var streamPos = stream.Position;
         stream.Seek(0, SeekOrigin.Begin);
         var bytes = new byte[stream.Length];
-        stream.Read(bytes, 0, (int) stream.Length);
+        var read = stream.Read(bytes, 0, (int) stream.Length);
+        if (read != stream.Length)
+            throw new IOException("Could not read the whole stream.");
         stream.Seek(streamPos, SeekOrigin.Begin);
         return encoding.GetString(bytes);
     }

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -57,6 +57,8 @@ for:
         - job_name: linux
     build_script:
       - cd $APPVEYOR_BUILD_FOLDER/Src
+      - curl -sSL https://dot.net/v1/dotnet-install.sh | bash /dev/stdin --channel 8.0
+      - export PATH="$HOME/.dotnet:$PATH"
       - dotnet --version
       - dotnet restore --verbosity quiet
       - dotnet add ./MailMergeLib.Tests/MailMergeLib.Tests.csproj package AltCover

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -65,4 +65,4 @@ for:
       - dotnet build MailMergeLib.sln /verbosity:minimal /t:rebuild /p:configuration=release /nowarn:CS1591,CS0618 
     test_script:
       - dotnet test --framework net8.0 MailMergeLib.sln /p:configuration=release /p:AltCover=true /p:AltCoverXmlReport="coverage.xml" /p:AltCover=true /p:AltCoverStrongNameKey="../MailMergeLib/MailMergeLib.snk" /p:AltCoverAssemblyExcludeFilter="MailMergeLib.Tests|NUnit3.TestAdapter" /p:AltCoverLineCover="true"
-      - bash <(curl -s https://codecov.io/bash) -f ./MailMergeLib.Tests/coverage.net6.0.xml -n net6.0linux
+      - bash <(curl -s https://codecov.io/bash) -f ./MailMergeLib.Tests/coverage.net8.0.xml -n net8.0linux

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -39,7 +39,7 @@ for:
       - cmd: nuget install Appveyor.TestLogger
       - cmd: dotnet test --framework net8.0 --test-adapter-path:. --logger:Appveyor MailMergeLib.sln /p:configuration=release /p:AltCover=true /p:AltCoverXmlReport="coverage.xml" /p:AltCover=true /p:AltCoverStrongNameKey="..\MailMergeLib\MailMergeLib.snk" /p:AltCoverAssemblyExcludeFilter="MailMergeLib.Tests|NUnit3.TestAdapter" /p:AltCoverLineCover="true"
       - cmd: nuget install codecov -excludeversion
-      - cmd: .\Codecov\Tools\win7-x86\codecov.exe -f ".\MailMergeLib.Tests\coverage.net6.0.xml" -n net6.0win
+      - cmd: .\Codecov\Tools\win7-x86\codecov.exe -f ".\MailMergeLib.Tests\coverage.net8.0.xml" -n net8.0win
     artifacts:
       - path: 'artifacts\*.nupkg'
         type: NuGetPackage

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -37,7 +37,7 @@ for:
           dotnet pack MailMergeLib.sln --verbosity minimal --no-build --configuration release /p:IncludeSymbols=true /p:SymbolPackageFormat=snupkg /p:PackageOutputPath=$env:APPVEYOR_BUILD_FOLDER/artifacts /p:ContinuousIntegrationBuild=true
     test_script:
       - cmd: nuget install Appveyor.TestLogger
-      - cmd: dotnet test --framework net6.0 --test-adapter-path:. --logger:Appveyor MailMergeLib.sln /p:configuration=release /p:AltCover=true /p:AltCoverXmlReport="coverage.xml" /p:AltCover=true /p:AltCoverStrongNameKey="..\MailMergeLib\MailMergeLib.snk" /p:AltCoverAssemblyExcludeFilter="MailMergeLib.Tests|NUnit3.TestAdapter" /p:AltCoverLineCover="true"
+      - cmd: dotnet test --framework net8.0 --test-adapter-path:. --logger:Appveyor MailMergeLib.sln /p:configuration=release /p:AltCover=true /p:AltCoverXmlReport="coverage.xml" /p:AltCover=true /p:AltCoverStrongNameKey="..\MailMergeLib\MailMergeLib.snk" /p:AltCoverAssemblyExcludeFilter="MailMergeLib.Tests|NUnit3.TestAdapter" /p:AltCoverLineCover="true"
       - cmd: nuget install codecov -excludeversion
       - cmd: .\Codecov\Tools\win7-x86\codecov.exe -f ".\MailMergeLib.Tests\coverage.net6.0.xml" -n net6.0win
     artifacts:
@@ -62,5 +62,5 @@ for:
       - dotnet add ./MailMergeLib.Tests/MailMergeLib.Tests.csproj package AltCover
       - dotnet build MailMergeLib.sln /verbosity:minimal /t:rebuild /p:configuration=release /nowarn:CS1591,CS0618 
     test_script:
-      - dotnet test --framework net6.0 MailMergeLib.sln /p:configuration=release /p:AltCover=true /p:AltCoverXmlReport="coverage.xml" /p:AltCover=true /p:AltCoverStrongNameKey="../MailMergeLib/MailMergeLib.snk" /p:AltCoverAssemblyExcludeFilter="MailMergeLib.Tests|NUnit3.TestAdapter" /p:AltCoverLineCover="true"
+      - dotnet test --framework net8.0 MailMergeLib.sln /p:configuration=release /p:AltCover=true /p:AltCoverXmlReport="coverage.xml" /p:AltCover=true /p:AltCoverStrongNameKey="../MailMergeLib/MailMergeLib.snk" /p:AltCoverAssemblyExcludeFilter="MailMergeLib.Tests|NUnit3.TestAdapter" /p:AltCoverLineCover="true"
       - bash <(curl -s https://codecov.io/bash) -f ./MailMergeLib.Tests/coverage.net6.0.xml -n net6.0linux


### PR DESCRIPTION
### MailMergeLib:
* AngleSharp 1.1.2 => 1.3.0
* MailKit 4.7.1.1 => 4.14.0
* MimeKit 4.7.1 => 4.14.0
* SmartFormat.NET 3.5.0 => 3.6.1
* System.Configuration.ConfigurationManager 8.0.0 => 9.0.9

###  MailMergeLib.Tests
* Updates referenced packages for MailMergeLib.Tests 
* Unit tests now target net462 and net8.0